### PR TITLE
Added calls to the ToApp and ToAdmin callbacks on the application object from within session

### DIFF
--- a/session.go
+++ b/session.go
@@ -169,6 +169,12 @@ func (s *Session) send(builder MessageBuilder) {
 	seqNum := s.store.NextSenderMsgSeqNum()
 	builder.Header().Set(fix.NewIntField(tag.MsgSeqNum, seqNum))
 
+	msgType := new(fix.StringValue)
+	if builder.Header().GetField(tag.MsgType, msgType); fix.IsAdminMessageType(msgType.Value) {
+		s.application.ToAdmin(builder, s.sessionID)
+	} else {
+		s.application.ToApp(builder, s.sessionID)
+	}
 	if msgBytes, err := builder.Build(); err != nil {
 		panic(err)
 	} else {


### PR DESCRIPTION
This is needed for applications that need to provide authentication credentials (username and password) on the Logon message, for example.

I'm not sure if this is the correct place for these calls, or if there are additional places where the calls are needed, but they allowed my application to authenticate correctly.
