### PR TITLE
Changed checksum calculation in Message and MessageBuilder to include Body length tag

### DIFF
--- a/message.go
+++ b/message.go
@@ -205,13 +205,13 @@ func (m *Message) rebuild() {
 	trailer := m.Trailer.(fieldMap)
 
 	bodyLength := header.length() + len(m.bodyBytes) + trailer.length()
+	header.Set(fix.NewIntField(tag.BodyLength, bodyLength))
 	checkSum := header.total() + trailer.total()
 	for _, b := range m.bodyBytes {
 		checkSum += int(b)
 	}
 	checkSum %= 256
 
-	header.Set(fix.NewIntField(tag.BodyLength, bodyLength))
 	trailer.Set(newCheckSum(checkSum))
 
 	var b bytes.Buffer

--- a/message_builder.go
+++ b/message_builder.go
@@ -44,7 +44,7 @@ func (m messageBuilder) Build() ([]byte, error) {
 
 func (m messageBuilder) cook() {
 	bodyLength := m.header.length() + m.body.length() + m.trailer.length()
-	checkSum := (m.header.total() + m.body.total() + m.trailer.total()) % 256
 	m.header.Set(fix.NewIntField(tag.BodyLength, bodyLength))
+	checkSum := (m.header.total() + m.body.total() + m.trailer.total()) % 256
 	m.trailer.Set(newCheckSum(checkSum))
 }

--- a/message_builder_test.go
+++ b/message_builder_test.go
@@ -1,0 +1,34 @@
+package quickfix
+
+import (
+	"bytes"
+	"github.com/quickfixgo/quickfix/fix"
+	"github.com/quickfixgo/quickfix/fix/tag"
+	"testing"
+	"github.com/quickfixgo/quickfix/fix/field"
+)
+
+var builder MessageBuilder
+
+func TestMessageBuilder_checkBuild(t *testing.T) {
+	builder = NewMessageBuilder()
+
+	builder.Header().Set(field.NewBeginString(fix.BeginString_FIX44))
+	builder.Header().Set(fix.NewStringField(tag.MsgType, "A"))
+	builder.Header().Set(fix.NewStringField(tag.SendingTime, "20140615-19:49:56"))
+
+	builder.Body().Set(field.NewUsername("my_user"))
+	builder.Body().Set(field.NewPassword("secret"))
+
+	expectedBytes := []byte("8=FIX.4.49=4935=A52=20140615-19:49:56553=my_user554=secret10=072")
+	result, err := builder.Build()
+	if err != nil {
+		t.Error("Unexpected error", err)
+	}
+
+	if !bytes.Equal(expectedBytes, result) {
+		t.Error("Unexpected bytes, got ", string(result))
+	}
+
+}
+

--- a/message_test.go
+++ b/message_test.go
@@ -66,7 +66,7 @@ func TestMessage_rebuild(t *testing.T) {
 
 	msg.rebuild()
 
-	expectedBytes := []byte("8=FIX.4.29=12635=D34=249=TW52=20140615-19:49:5656=ISLD122=20140515-19:49:56.65911=10021=140=154=155=TSLA60=00010101-00:00:00.00010=124")
+	expectedBytes := []byte("8=FIX.4.29=12635=D34=249=TW52=20140615-19:49:5656=ISLD122=20140515-19:49:56.65911=10021=140=154=155=TSLA60=00010101-00:00:00.00010=128")
 
 	if !bytes.Equal(expectedBytes, msg.rawMessage) {
 		t.Error("Unexpected bytes, got ", string(msg.rawMessage))


### PR DESCRIPTION
I am certainly not a FIX protocol export, so I may be wrong here, but I believe the body length tag needs to be included in the checksum calculation.  The server I am integrating with rejected my messages until I made this change, and references to the spec indicate that only the checksum tag itself should be excluded.  For example:

http://www.onixs.biz/fix-dictionary/4.2/app_b.html
