### PR TITLE
Make settings parser case insensitive for headers

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -65,8 +65,8 @@ func ParseSettings(reader io.Reader) (*Settings, error) {
 	scanner := bufio.NewScanner(reader)
 	blankRegEx := regexp.MustCompile(`^\s*$`)
 	commentRegEx := regexp.MustCompile(`^#.*`)
-	defaultRegEx := regexp.MustCompile(`^\[DEFAULT\]\s*$`)
-	sessionRegEx := regexp.MustCompile(`^\[SESSION\]\s*$`)
+	defaultRegEx := regexp.MustCompile(`^\[(?i)DEFAULT\]\s*$`)
+	sessionRegEx := regexp.MustCompile(`^\[(?i)SESSION\]\s*$`)
 	settingRegEx := regexp.MustCompile(`^(.*)=(.*)$`)
 
 	var settings *SessionSettings


### PR DESCRIPTION
I want to be able to use lower case headers for the settings file, so as not to modify them when they are provided by a third party. This little change does the job.