### PR TITLE
Do not specify full template in repeating group reads

### DIFF
--- a/repeating_group.go
+++ b/repeating_group.go
@@ -3,6 +3,7 @@ package quickfix
 import (
 	"bytes"
 	"strconv"
+	"fmt"
 )
 
 type RepeatingGroupField struct {
@@ -69,7 +70,8 @@ func (f *RepeatingGroup) Read(tv TagValues) (TagValues, error) {
 	for len(tv) > 0 {
 		field, ok := f.findFieldInGroupTemplate(tv[0].Tag)
 		if !ok {
-			break
+			tv = tv[1:]
+			continue
 		}
 
 		if tv, err = field.Read(tv); err != nil {
@@ -90,6 +92,9 @@ func (f *RepeatingGroup) Read(tv TagValues) (TagValues, error) {
 		}
 	}
 
+	if len(f.Groups) != expectedGroupSize {
+		return tv, fmt.Errorf("Only found %v instead of %v expected groups, is template wrong?", len(group), expectedGroupSize)
+	}
 	return tv, err
 }
 

--- a/repeating_group.go
+++ b/repeating_group.go
@@ -2,9 +2,9 @@ package quickfix
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"strconv"
-	"fmt"
 )
 
 type RepeatingGroupField struct {

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -79,12 +79,26 @@ func TestRepeatingGroup_Read(t *testing.T) {
 				[][]byte{[]byte("hello")},
 				[][]byte{[]byte("goodbye"), []byte("cruel"), []byte("world")},
 				[][]byte{[]byte("another")}}},
+		{multiFieldTemplate, TagValues{
+			TagValue{Value: []byte("2")},
+			TagValue{Tag: Tag(4), Value: []byte("not in template 1")},
+			TagValue{Tag: Tag(1), Value: []byte("hello")},
+			TagValue{Tag: Tag(5), Value: []byte("not in template 2")},
+			TagValue{Tag: Tag(2), Value: []byte("world")},
+			TagValue{Tag: Tag(1), Value: []byte("another")},
+		}, 2,
+			[][][]byte{
+				[][]byte{[]byte("hello"), []byte("world")},
+				[][]byte{[]byte("another")}}},
 	}
 
 	for _, test := range tests {
 		f := RepeatingGroup{GroupTemplate: test.groupTemplate}
 
-		f.Read(test.tv)
+		_, err := f.Read(test.tv)
+		if err != nil {
+			t.Error(err)
+		}
 		if len(f.Groups) != test.expectedGroupNum {
 			t.Errorf("expected %v groups, got %v", test.expectedGroupNum, len(f.Groups))
 		}


### PR DESCRIPTION
Check repeated group count in read but keep iterating on the tag values if an unknown field if found, allowing to only specify a small template. This is exclusive with the previous pull request (only one should be accepted).