### PR TITLE
message cap, removed repeating group cruft

### DIFF
--- a/field.go
+++ b/field.go
@@ -8,22 +8,14 @@ type FieldValueWriter interface {
 
 //FieldValueReader is an interface for reading field values
 type FieldValueReader interface {
-	//Parameter to Read is TagValues.  For most fields, only the first TagValue will be required.
-	//The length of the slice extends from the TagValue mapped to the field to be read through the
-	//following fields. This can be useful for FieldValues made up of repeating groups.
-	//
-	//The Read function returns the remaining TagValues not processed by the FieldValue. If there was a
-	//problem reading the field, an error may be returned
-	Read(TagValues) (TagValues, error)
+	//Reads the contents of the []byte into FieldValue.  Returns an error if there are issues in the data processing
+	Read([]byte) error
 }
 
 //The FieldValue interface is used to write/extract typed field values to/from raw bytes
 type FieldValue interface {
 	FieldValueWriter
 	FieldValueReader
-
-	//Returns a new FieldValue cloned from this one
-	Clone() FieldValue
 }
 
 //FieldWriter is an interface for a writing a field

--- a/field_map.go
+++ b/field_map.go
@@ -103,14 +103,14 @@ func (m FieldMap) GetField(tag Tag, parser FieldValueReader) MessageRejectError 
 	return nil
 }
 
-func (m FieldMap) GetGroupField(tag Tag, parser *RepeatingGroup) MessageRejectError {
-	tagValues, ok := m.tagLookup[tag]
+func (m FieldMap) GetGroup(parser *RepeatingGroup) MessageRejectError {
+	tagValues, ok := m.tagLookup[parser.Tag]
 	if !ok {
-		return conditionallyRequiredFieldMissing(tag)
+		return conditionallyRequiredFieldMissing(parser.Tag)
 	}
 
 	if _, err := parser.Read(tagValues); err != nil {
-		return incorrectDataFormatForValue(tag)
+		return incorrectDataFormatForValue(parser.Tag)
 	}
 
 	return nil
@@ -130,6 +130,11 @@ func (m FieldMap) Set(field FieldWriter) FieldMap {
 	return m
 }
 
+func (m FieldMap) SetGroup(field RepeatingGroup) FieldMap {
+	m.tagLookup[field.Tag] = field.TagValues()
+	return m
+}
+
 func (m FieldMap) sortedTags() []Tag {
 	sortedTags := make([]Tag, len(m.tagLookup))
 	for tag := range m.tagLookup {
@@ -145,7 +150,9 @@ func (m FieldMap) write(buffer *bytes.Buffer) {
 
 	for _, tag := range tags {
 		if fields, ok := m.tagLookup[tag]; ok {
-			buffer.Write(fields[0].bytes)
+			for _, tv := range fields {
+				buffer.Write(tv.bytes)
+			}
 		}
 	}
 }
@@ -153,11 +160,12 @@ func (m FieldMap) write(buffer *bytes.Buffer) {
 func (m FieldMap) total() int {
 	total := 0
 	for _, fields := range m.tagLookup {
-		field := fields[0]
-		switch field.Tag {
-		case tagCheckSum: //tag does not contribute to total
-		default:
-			total += field.total()
+		for _, tv := range fields {
+			switch tv.Tag {
+			case tagCheckSum: //tag does not contribute to total
+			default:
+				total += tv.total()
+			}
 		}
 	}
 
@@ -167,11 +175,12 @@ func (m FieldMap) total() int {
 func (m FieldMap) length() int {
 	length := 0
 	for _, fields := range m.tagLookup {
-		field := fields[0]
-		switch field.Tag {
-		case tagBeginString, tagBodyLength, tagCheckSum: //tags do not contribute to length
-		default:
-			length += field.length()
+		for _, tv := range fields {
+			switch tv.Tag {
+			case tagBeginString, tagBodyLength, tagCheckSum: //tags do not contribute to length
+			default:
+				length += tv.length()
+			}
 		}
 	}
 

--- a/field_map.go
+++ b/field_map.go
@@ -96,6 +96,19 @@ func (m FieldMap) GetField(tag Tag, parser FieldValueReader) MessageRejectError 
 		return conditionallyRequiredFieldMissing(tag)
 	}
 
+	if err := parser.Read(tagValues[0].Value); err != nil {
+		return incorrectDataFormatForValue(tag)
+	}
+
+	return nil
+}
+
+func (m FieldMap) GetGroupField(tag Tag, parser *RepeatingGroup) MessageRejectError {
+	tagValues, ok := m.tagLookup[tag]
+	if !ok {
+		return conditionallyRequiredFieldMissing(tag)
+	}
+
 	if _, err := parser.Read(tagValues); err != nil {
 		return incorrectDataFormatForValue(tag)
 	}

--- a/fix_boolean.go
+++ b/fix_boolean.go
@@ -13,18 +13,17 @@ func NewFIXBoolean(val bool) *FIXBoolean {
 	return &b
 }
 
-func (f *FIXBoolean) Read(tv TagValues) (TagValues, error) {
-	bytes := tv[0].Value
+func (f *FIXBoolean) Read(bytes []byte) error {
 	switch string(bytes) {
 	case "Y":
 		*f = true
 	case "N":
 		*f = false
 	default:
-		return tv, errors.New("Invalid Value for bool: " + string(bytes))
+		return errors.New("Invalid Value for bool: " + string(bytes))
 	}
 
-	return tv[1:], nil
+	return nil
 }
 
 func (f FIXBoolean) Write() []byte {
@@ -33,9 +32,4 @@ func (f FIXBoolean) Write() []byte {
 	}
 
 	return []byte("N")
-}
-
-func (f FIXBoolean) Clone() FieldValue {
-	clone := f
-	return &clone
 }

--- a/fix_boolean_test.go
+++ b/fix_boolean_test.go
@@ -37,7 +37,7 @@ func TestFIXBooleanFieldRead(t *testing.T) {
 
 	for _, test := range tests {
 		var val FIXBoolean
-		_, err := val.Read([]TagValue{TagValue{Value: test.bytes}})
+		err := val.Read(test.bytes)
 
 		if test.expectError && err == nil {
 			t.Errorf("Expected error for %v", test.bytes)

--- a/fix_float.go
+++ b/fix_float.go
@@ -15,28 +15,22 @@ func NewFIXFloat(val float64) *FIXFloat {
 	return &f
 }
 
-func (f *FIXFloat) Read(tv TagValues) (TagValues, error) {
-	bytes := tv[0].Value
+func (f *FIXFloat) Read(bytes []byte) error {
 	val, err := strconv.ParseFloat(string(bytes), 64)
 	if err != nil {
-		return tv, err
+		return err
 	}
 
 	//strconv allows values like "+100.00", which is not allowed for FIX float types
 	if valid, _ := regexp.MatchString("^[0-9.-]+$", string(bytes)); !valid {
-		return tv, fmt.Errorf("invalid value %v", string(bytes))
+		return fmt.Errorf("invalid value %v", string(bytes))
 	}
 
 	*f = FIXFloat(val)
 
-	return tv[1:], err
+	return err
 }
 
 func (f FIXFloat) Write() []byte {
 	return []byte(strconv.FormatFloat(float64(f), 'f', -1, 64))
-}
-
-func (f FIXFloat) Clone() FieldValue {
-	clone := f
-	return &clone
 }

--- a/fix_float_test.go
+++ b/fix_float_test.go
@@ -35,7 +35,7 @@ func TestFloatRead(t *testing.T) {
 
 	for _, test := range tests {
 		var field FIXFloat
-		if _, err := field.Read([]TagValue{TagValue{Value: test.bytes}}); err != nil {
+		if err := field.Read(test.bytes); err != nil {
 			if !test.expectError {
 				t.Errorf("UnExpected '%v'", err)
 			}

--- a/fix_int.go
+++ b/fix_int.go
@@ -52,20 +52,15 @@ func NewFIXInt(val int) *FIXInt {
 	return &i
 }
 
-func (f *FIXInt) Read(tv TagValues) (TagValues, error) {
-	i, err := atoi(tv[0].Value)
+func (f *FIXInt) Read(bytes []byte) error {
+	i, err := atoi(bytes)
 	if err != nil {
-		return tv, err
+		return err
 	}
 	*f = FIXInt(i)
-	return tv[1:], nil
+	return nil
 }
 
 func (f FIXInt) Write() []byte {
 	return []byte(strconv.Itoa(int(f)))
-}
-
-func (f FIXInt) Clone() FieldValue {
-	clone := f
-	return &clone
 }

--- a/fix_int_test.go
+++ b/fix_int_test.go
@@ -15,7 +15,7 @@ func TestInt_Write(t *testing.T) {
 
 func TestInt_Read(t *testing.T) {
 	var field FIXInt
-	_, err := field.Read([]TagValue{TagValue{Value: []byte("15")}})
+	err := field.Read([]byte("15"))
 
 	if err != nil {
 		t.Error("Unexpected error", err)
@@ -25,7 +25,7 @@ func TestInt_Read(t *testing.T) {
 		t.Error("unexpected value", field)
 	}
 
-	_, err = field.Read([]TagValue{TagValue{Value: []byte("blah")}})
+	err = field.Read([]byte("blah"))
 
 	if err == nil {
 		t.Error("expected error")
@@ -37,6 +37,6 @@ func BenchmarkInt_Read(b *testing.B) {
 	var field FIXInt
 
 	for i := 0; i < b.N; i++ {
-		field.Read([]TagValue{TagValue{Value: intBytes}})
+		field.Read(intBytes)
 	}
 }

--- a/fix_string.go
+++ b/fix_string.go
@@ -13,16 +13,11 @@ func (f FIXString) String() string {
 	return string(f)
 }
 
-func (f *FIXString) Read(tv TagValues) (TagValues, error) {
-	*f = FIXString(tv[0].Value)
-	return tv[1:], nil
+func (f *FIXString) Read(bytes []byte) (err error) {
+	*f = FIXString(bytes)
+	return
 }
 
 func (f FIXString) Write() []byte {
 	return []byte(f)
-}
-
-func (f FIXString) Clone() FieldValue {
-	clone := f
-	return &clone
 }

--- a/fix_string_test.go
+++ b/fix_string_test.go
@@ -33,7 +33,7 @@ func TestFIXStringRead(t *testing.T) {
 
 	for _, test := range tests {
 		var field FIXString
-		_, err := field.Read([]TagValue{TagValue{Value: test.bytes}})
+		err := field.Read(test.bytes)
 
 		if test.expectError && err == nil {
 			t.Errorf("Expected error for %v", test.bytes)

--- a/fix_utc_timestamp.go
+++ b/fix_utc_timestamp.go
@@ -15,20 +15,19 @@ const (
 	utcTimestampNoMillisFormat = "20060102-15:04:05"
 )
 
-func (f *FIXUTCTimestamp) Read(tv TagValues) (TagValues, error) {
-	bytes := tv[0].Value
+func (f *FIXUTCTimestamp) Read(bytes []byte) error {
 	var err error
 	//with millisecs
 	if f.Value, err = time.Parse(utcTimestampFormat, string(bytes)); err == nil {
-		return tv[1:], nil
+		return nil
 	}
 
 	//w/o millisecs
 	if f.Value, err = time.Parse(utcTimestampNoMillisFormat, string(bytes)); err != nil {
-		return tv, err
+		return err
 	}
 
-	return tv[1:], nil
+	return nil
 }
 
 func (f FIXUTCTimestamp) Write() []byte {
@@ -37,8 +36,4 @@ func (f FIXUTCTimestamp) Write() []byte {
 	}
 
 	return []byte(f.Value.UTC().Format(utcTimestampFormat))
-}
-
-func (f FIXUTCTimestamp) Clone() FieldValue {
-	return &FIXUTCTimestamp{f.Value, f.NoMillis}
 }

--- a/message.go
+++ b/message.go
@@ -67,7 +67,7 @@ func parseMessage(rawMessage []byte) (Message, error) {
 		return msg, err
 	}
 
-	msg.Header.tagLookup[msg.fields[fieldIndex].Tag] = msg.fields[fieldIndex:]
+	msg.Header.tagLookup[msg.fields[fieldIndex].Tag] = msg.fields[fieldIndex : fieldIndex+1]
 	fieldIndex++
 
 	parsedFieldBytes := &msg.fields[fieldIndex]
@@ -75,7 +75,7 @@ func parseMessage(rawMessage []byte) (Message, error) {
 		return msg, err
 	}
 
-	msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex:]
+	msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex : fieldIndex+1]
 	fieldIndex++
 
 	parsedFieldBytes = &msg.fields[fieldIndex]
@@ -83,7 +83,7 @@ func parseMessage(rawMessage []byte) (Message, error) {
 		return msg, err
 	}
 
-	msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex:]
+	msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex : fieldIndex+1]
 	fieldIndex++
 
 	trailerBytes := []byte{}
@@ -97,13 +97,13 @@ func parseMessage(rawMessage []byte) (Message, error) {
 
 		switch {
 		case parsedFieldBytes.Tag.IsHeader():
-			msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex:]
+			msg.Header.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex : fieldIndex+1]
 		case parsedFieldBytes.Tag.IsTrailer():
-			msg.Trailer.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex:]
+			msg.Trailer.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex : fieldIndex+1]
 		default:
 			foundBody = true
 			trailerBytes = rawMessage
-			msg.Body.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex:]
+			msg.Body.tagLookup[parsedFieldBytes.Tag] = msg.fields[fieldIndex : fieldIndex+1]
 		}
 		if parsedFieldBytes.Tag == tagCheckSum {
 			break
@@ -210,6 +210,7 @@ func newCheckSum(value int) FIXString {
 	return FIXString(fmt.Sprintf("%03d", value))
 }
 
+//Build constructs a []byte from a Message instance
 func (m *Message) Build() ([]byte, error) {
 	m.cook()
 

--- a/parser.go
+++ b/parser.go
@@ -114,7 +114,7 @@ func (p *parser) ReadMessage() ([]byte, error) {
 		return []byte{}, err
 	}
 
-	msgBytes := p.buffer[:index]
+	msgBytes := p.buffer[:index:index]
 	p.buffer = p.buffer[index:]
 
 	return msgBytes, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -128,6 +128,10 @@ func TestParser_ReadMessage(t *testing.T) {
 			t.Errorf("Expected %v got %v", tc.expectedBytes, string(msg))
 		}
 
+		if len(tc.expectedBytes) != cap(msg) {
+			t.Errorf("Expected capacity %v got %v", len(tc.expectedBytes), cap(msg))
+		}
+
 		if cap(parser.buffer) != tc.expectedBufferCap {
 			t.Errorf("Expected capacity %v got %v", tc.expectedBufferCap, cap(parser.buffer))
 		}

--- a/repeating_group.go
+++ b/repeating_group.go
@@ -7,12 +7,41 @@ import (
 	"strconv"
 )
 
-type RepeatingGroupField struct {
-	Tag
-	FieldValue
+//GroupItem interface is used to construct repeating group templates
+type GroupItem interface {
+	//Tag returns the tag identifying this GroupItem
+	Tag() Tag
+
+	//Parameter to Read is TagValues.  For most fields, only the first TagValue will be required.
+	//The length of the slice extends from the TagValue mapped to the field to be read through the
+	//following fields. This can be useful for GroupItems made up of repeating groups.
+	//
+	//The Read function returns the remaining TagValues not processed by the GroupItem. If there was a
+	//problem reading the field, an error may be returned
+	Read(TagValues) (TagValues, error)
 }
 
-type GroupTemplate []RepeatingGroupField
+type protoGroupElement struct {
+	tagMethod func() Tag
+}
+
+func (t protoGroupElement) Tag() Tag { return t.tagMethod() }
+func (t protoGroupElement) Read(tv TagValues) (TagValues, error) {
+	if tv[0].Tag == t.tagMethod() {
+		return tv[1:], nil
+	}
+
+	return tv, nil
+}
+
+//GroupElement returns a GroupItem made up of a single field
+func GroupElement(tag Tag) GroupItem {
+	t := struct{ protoGroupElement }{}
+	t.tagMethod = func() Tag { return tag }
+	return t
+}
+
+type GroupTemplate []GroupItem
 type Group struct{ FieldMap }
 
 type RepeatingGroup struct {
@@ -20,6 +49,7 @@ type RepeatingGroup struct {
 	Groups []Group
 }
 
+//Add appends a new group to the RepeatingGroup and returns the new Group
 func (f *RepeatingGroup) Add() Group {
 	var g Group
 	g.init(f.groupTagOrder())
@@ -41,12 +71,11 @@ func (f RepeatingGroup) Write() []byte {
 	return bytes[:len(bytes)-1]
 }
 
-func (f RepeatingGroup) findFieldInGroupTemplate(t Tag) (field RepeatingGroupField, ok bool) {
+func (f RepeatingGroup) findItemInGroupTemplate(t Tag) (item GroupItem, ok bool) {
 	for _, templateField := range f.GroupTemplate {
-		if t == templateField.Tag {
+		if t == templateField.Tag() {
 			ok = true
-			field.Tag = templateField.Tag
-			field.FieldValue = templateField.Clone()
+			item = templateField
 			break
 		}
 	}
@@ -57,7 +86,7 @@ func (f RepeatingGroup) findFieldInGroupTemplate(t Tag) (field RepeatingGroupFie
 func (f RepeatingGroup) groupTagOrder() tagOrder {
 	tagMap := make(map[Tag]int)
 	for i, f := range f.GroupTemplate {
-		tagMap[f.Tag] = i
+		tagMap[f.Tag()] = i
 	}
 
 	return func(i, j Tag) bool {
@@ -77,7 +106,7 @@ func (f RepeatingGroup) groupTagOrder() tagOrder {
 }
 
 func (f RepeatingGroup) isDelimiter(t Tag) bool {
-	return t == f.GroupTemplate[0].Tag
+	return t == f.GroupTemplate[0].Tag()
 }
 
 func (f *RepeatingGroup) Read(tv TagValues) (TagValues, error) {
@@ -96,43 +125,28 @@ func (f *RepeatingGroup) Read(tv TagValues) (TagValues, error) {
 	var group Group
 	group.init(tagOrdering)
 	for len(tv) > 0 {
-		field, ok := f.findFieldInGroupTemplate(tv[0].Tag)
+		field, ok := f.findItemInGroupTemplate(tv[0].Tag)
 		if !ok {
 			break
 		}
 
+		tvRange := tv
 		if tv, err = field.Read(tv); err != nil {
 			return tv, err
 		}
 
-		if f.isDelimiter(field.Tag) {
+		if f.isDelimiter(field.Tag()) {
 			group = Group{}
 			group.init(tagOrdering)
 
 			f.Groups = append(f.Groups, group)
 		}
 
-		group.SetField(field.Tag, field)
+		group.tagLookup[tvRange[0].Tag] = tvRange
 	}
 
 	if len(f.Groups) != expectedGroupSize {
 		return tv, fmt.Errorf("Only found %v instead of %v expected groups, is template wrong?", len(f.Groups), expectedGroupSize)
 	}
 	return tv, err
-}
-
-func (f RepeatingGroup) Clone() FieldValue {
-	var clone RepeatingGroup
-	clone.GroupTemplate = make(GroupTemplate, len(f.GroupTemplate))
-	clone.Groups = make([]Group, len(f.Groups))
-
-	for i, field := range f.GroupTemplate {
-		clone.GroupTemplate[i] = RepeatingGroupField{field.Tag, field.FieldValue.Clone()}
-	}
-
-	for i, group := range f.Groups {
-		clone.Groups[i].init(group.tagOrder)
-	}
-
-	return &clone
 }

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRepeatingGroup_Add(t *testing.T) {
-	f := RepeatingGroup{GroupTemplate: GroupTemplate{RepeatingGroupField{1, new(FIXString)}}}
+	f := RepeatingGroup{GroupTemplate: GroupTemplate{GroupElement(1)}}
 
 	var tests = []struct {
 		expectedLen int
@@ -38,28 +38,28 @@ func TestRepeatingGroup_Add(t *testing.T) {
 
 func TestRepeatingGroup_Write(t *testing.T) {
 	f1 := RepeatingGroup{GroupTemplate: GroupTemplate{
-		RepeatingGroupField{1, new(FIXString)},
-		RepeatingGroupField{2, new(FIXString)},
+		GroupElement(1),
+		GroupElement(2),
 	}}
 
 	f1.Add().SetField(Tag(1), FIXString("hello"))
 
 	f2 := RepeatingGroup{GroupTemplate: GroupTemplate{
-		RepeatingGroupField{1, new(FIXString)},
-		RepeatingGroupField{2, new(FIXString)},
+		GroupElement(1),
+		GroupElement(2),
 	}}
 	f2.Add().SetField(Tag(1), FIXString("hello")).SetField(Tag(2), FIXString("world"))
 
 	f3 := RepeatingGroup{GroupTemplate: GroupTemplate{
-		RepeatingGroupField{1, new(FIXString)},
-		RepeatingGroupField{2, new(FIXString)},
+		GroupElement(1),
+		GroupElement(2),
 	}}
 	f3.Add().SetField(Tag(1), FIXString("hello"))
 	f3.Add().SetField(Tag(1), FIXString("world"))
 
 	f4 := RepeatingGroup{GroupTemplate: GroupTemplate{
-		RepeatingGroupField{1, new(FIXString)},
-		RepeatingGroupField{2, new(FIXString)},
+		GroupElement(1),
+		GroupElement(2),
 	}}
 	f4.Add().SetField(Tag(1), FIXString("hello")).SetField(Tag(2), FIXString("world"))
 	f4.Add().SetField(Tag(1), FIXString("goodbye"))
@@ -83,7 +83,7 @@ func TestRepeatingGroup_Write(t *testing.T) {
 }
 
 func TestRepeatingGroup_ReadError(t *testing.T) {
-	singleFieldTemplate := GroupTemplate{RepeatingGroupField{Tag(1), new(FIXString)}}
+	singleFieldTemplate := GroupTemplate{GroupElement(1)}
 	tests := []struct {
 		tv               TagValues
 		expectedGroupNum int
@@ -113,8 +113,8 @@ func TestRepeatingGroup_ReadError(t *testing.T) {
 
 func TestRepeatingGroup_Read(t *testing.T) {
 
-	singleFieldTemplate := GroupTemplate{RepeatingGroupField{Tag(1), new(FIXString)}}
-	multiFieldTemplate := GroupTemplate{RepeatingGroupField{Tag(1), new(FIXString)}, RepeatingGroupField{Tag(2), new(FIXString)}, RepeatingGroupField{Tag(3), new(FIXString)}}
+	singleFieldTemplate := GroupTemplate{GroupElement(1)}
+	multiFieldTemplate := GroupTemplate{GroupElement(1), GroupElement(2), GroupElement(3)}
 
 	tests := []struct {
 		groupTemplate    GroupTemplate
@@ -198,15 +198,15 @@ func TestRepeatingGroup_ReadComplete(t *testing.T) {
 	}
 
 	template := GroupTemplate{
-		RepeatingGroupField{Tag(269), new(FIXString)},
-		RepeatingGroupField{Tag(270), new(FIXString)},
-		RepeatingGroupField{Tag(271), new(FIXString)},
-		RepeatingGroupField{Tag(272), new(FIXString)},
-		RepeatingGroupField{Tag(273), new(FIXString)},
+		GroupElement(269),
+		GroupElement(270),
+		GroupElement(271),
+		GroupElement(272),
+		GroupElement(273),
 	}
 
 	f := RepeatingGroup{GroupTemplate: template}
-	err = msg.Body.GetField(Tag(268), &f)
+	err = msg.Body.GetGroupField(Tag(268), &f)
 	if err != nil {
 		t.Error("Unexpected error, ", err)
 	}

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -36,28 +36,28 @@ func TestRepeatingGroup_Add(t *testing.T) {
 	}
 }
 
-func TestRepeatingGroup_Write(t *testing.T) {
-	f1 := RepeatingGroup{GroupTemplate: GroupTemplate{
+func TestRepeatingGroup_TagValues(t *testing.T) {
+	f1 := RepeatingGroup{Tag: 10, GroupTemplate: GroupTemplate{
 		GroupElement(1),
 		GroupElement(2),
 	}}
 
 	f1.Add().SetField(Tag(1), FIXString("hello"))
 
-	f2 := RepeatingGroup{GroupTemplate: GroupTemplate{
+	f2 := RepeatingGroup{Tag: 11, GroupTemplate: GroupTemplate{
 		GroupElement(1),
 		GroupElement(2),
 	}}
 	f2.Add().SetField(Tag(1), FIXString("hello")).SetField(Tag(2), FIXString("world"))
 
-	f3 := RepeatingGroup{GroupTemplate: GroupTemplate{
+	f3 := RepeatingGroup{Tag: 12, GroupTemplate: GroupTemplate{
 		GroupElement(1),
 		GroupElement(2),
 	}}
 	f3.Add().SetField(Tag(1), FIXString("hello"))
 	f3.Add().SetField(Tag(1), FIXString("world"))
 
-	f4 := RepeatingGroup{GroupTemplate: GroupTemplate{
+	f4 := RepeatingGroup{Tag: 13, GroupTemplate: GroupTemplate{
 		GroupElement(1),
 		GroupElement(2),
 	}}
@@ -68,16 +68,20 @@ func TestRepeatingGroup_Write(t *testing.T) {
 		f        RepeatingGroup
 		expected []byte
 	}{
-		{f1, []byte("11=hello")},
-		{f2, []byte("11=hello2=world")},
-		{f3, []byte("21=hello1=world")},
-		{f4, []byte("21=hello2=world1=goodbye")},
+		{f1, []byte("10=11=hello")},
+		{f2, []byte("11=11=hello2=world")},
+		{f3, []byte("12=21=hello1=world")},
+		{f4, []byte("13=21=hello2=world1=goodbye")},
 	}
 
 	for _, test := range tests {
-		fieldBytes := test.f.Write()
-		if !bytes.Equal(test.expected, fieldBytes) {
-			t.Errorf("expected %s got %s", test.expected, fieldBytes)
+		tvbytes := []byte{}
+		for _, tv := range test.f.TagValues() {
+			tvbytes = append(tvbytes, tv.bytes...)
+		}
+
+		if !bytes.Equal(test.expected, tvbytes) {
+			t.Errorf("expected %s got %s", test.expected, tvbytes)
 		}
 	}
 }
@@ -205,8 +209,8 @@ func TestRepeatingGroup_ReadComplete(t *testing.T) {
 		GroupElement(273),
 	}
 
-	f := RepeatingGroup{GroupTemplate: template}
-	err = msg.Body.GetGroupField(Tag(268), &f)
+	f := RepeatingGroup{Tag: 268, GroupTemplate: template}
+	err = msg.Body.GetGroup(&f)
 	if err != nil {
 		t.Error("Unexpected error, ", err)
 	}

--- a/validation.go
+++ b/validation.go
@@ -139,7 +139,7 @@ func validateVisitGroupField(fieldDef *datadictionary.FieldDef, fieldStack []Tag
 	numInGroupTag := fieldStack[0].Tag
 	var numInGroup FIXInt
 
-	if _, err := numInGroup.Read(fieldStack); err != nil {
+	if err := numInGroup.Read(fieldStack[0].Value); err != nil {
 		return nil, incorrectDataFormatForValue(numInGroupTag)
 	}
 
@@ -340,7 +340,7 @@ func validateField(d *datadictionary.DataDictionary, validFields datadictionary.
 
 	}
 
-	if _, err := prototype.Read(TagValues{field}); err != nil {
+	if err := prototype.Read(field.Value); err != nil {
 		return incorrectDataFormatForValue(field.Tag)
 	}
 


### PR DESCRIPTION
* Reverted some interface complexities introduced with first cut of repeating groups.  Not necessary to build repeating group templates with actual fields.
* Set message bytes capacity in parser.  Was an oversight.