### PR TITLE
Fix some typos and re-generate code.

### DIFF
--- a/_gen/generate-messages/main.go
+++ b/_gen/generate-messages/main.go
@@ -41,7 +41,7 @@ func genMessages() {
 
 func genMessageImports() string {
 	fileOut := `
-import( 
+import(
   "github.com/quickfixgo/quickfix"
   "github.com/quickfixgo/quickfix/enum"
 `
@@ -247,7 +247,7 @@ func genMessageRoute(msg *datadictionary.MessageDef) string {
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string,string,quickfix.MessageRoute) {
 	r:=func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m:=new(Message)

--- a/doc.go
+++ b/doc.go
@@ -5,35 +5,35 @@ Creating your QuickFIX Application
 
 Creating a FIX application is as easy as implementing the QuickFIX Application interface. By implementing these interface methods in your derived type, you are requesting to be notified of events that occur on the FIX engine.  The function that you should be most aware of is fromApp.
 
-Here are explanations of what these functions provide for you.
+Here are explanations of what these callback functions provide for you.
 
  OnCreate(sessionID SessionID)
 
-This method is called when quickfix creates a new session. A session comes into and remains in existence for the life of the application. Sessions exist whether or not a counter party is connected to it. As soon as a session is created, you can begin sending messages to it. If no one is logged on, the messages will be sent at the time a connection is established with the counterparty.
+OnCreate is called when quickfix creates a new session. A session comes into and remains in existence for the life of the application. Sessions exist whether or not a counter party is connected to it. As soon as a session is created, you can begin sending messages to it. If no one is logged on, the messages will be sent at the time a connection is established with the counterparty.
 
  OnLogon(sessionID SessionID)
 
-This callback notifies you when a valid logon has been established with a counter party. This is called when a connection has been established and the FIX logon process has completed with both parties exchanging valid logon messages.
+OnLogon notifies you when a valid logon has been established with a counter party. This is called when a connection has been established and the FIX logon process has completed with both parties exchanging valid logon messages.
 
  OnLogout(sessionID SessionID)
 
-This callback notifies you when an FIX session is no longer online. This could happen during a normal logout exchange or because of a forced termination or a loss of network connection.
+OnLogout notifies you when an FIX session is no longer online. This could happen during a normal logout exchange or because of a forced termination or a loss of network connection.
 
 	ToAdmin(message Message, sessionID SessionID)
 
-This callback provides you with a peak at the administrative messages that are being sent from your FIX engine to the counter party. This is normally not useful for an application however it is provided for any logging you may wish to do. Notice that the Message is not const. This allows you to add fields before an adminstrative message before it is sent out.
+ToAdmin provides you with a peak at the administrative messages that are being sent from your FIX engine to the counter party. This is normally not useful for an application however it is provided for any logging you may wish to do. Notice that the Message is not const. This allows you to add fields before an adminstrative message is sent out.
 
 	ToApp(message Message, sessionID SessionID) error
 
-This is a callback for application messages that you are being sent to a counterparty. Notice that the Message is not const. This allows you to add fields before an application message before it is sent out.
+ToApp notifies you of application messages that you are being sent to a counterparty. Notice that the Message is not const. This allows you to add fields before an application message before it is sent out.
 
 	FromAdmin(message Message, sessionID SessionID) MessageRejectError
 
-This callback notifies you when an administrative message is sent from a counterparty to your FIX engine. This can be usefull for doing extra validation on logon messages such as for checking passwords.
+FromAdmin notifies you when an administrative message is sent from a counterparty to your FIX engine. This can be usefull for doing extra validation on logon messages such as for checking passwords.
 
 	FromApp(msg Message, sessionID SessionID) MessageRejectError
 
-This is one of the core entry points for your FIX application. Every application level request will come through here. If, for example, your application is a sell-side OMS, this is where you will get your new order requests. If you were a buy side, you would get your execution reports here.
+FromApp is one of the core entry points for your FIX application. Every application level request will come through here. If, for example, your application is a sell-side OMS, this is where you will get your new order requests. If you were a buy side, you would get your execution reports here.
 
 The sample code below shows how you might start up a FIX acceptor which listens on a socket. If you wanted an initiator, you would simply replace NewAcceptor in this code fragment with NewInitiator.
 

--- a/fix40/advertisement/Advertisement.go
+++ b/fix40/advertisement/Advertisement.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/allocation/Allocation.go
+++ b/fix40/allocation/Allocation.go
@@ -133,7 +133,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/allocationack/AllocationACK.go
+++ b/fix40/allocationack/AllocationACK.go
@@ -37,7 +37,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/dontknowtrade/DontKnowTrade.go
+++ b/fix40/dontknowtrade/DontKnowTrade.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/email/Email.go
+++ b/fix40/email/Email.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/executionreport/ExecutionReport.go
+++ b/fix40/executionreport/ExecutionReport.go
@@ -121,7 +121,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/heartbeat/Heartbeat.go
+++ b/fix40/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/indicationofinterest/IndicationofInterest.go
+++ b/fix40/indicationofinterest/IndicationofInterest.go
@@ -59,7 +59,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/listcancelrequest/ListCancelRequest.go
+++ b/fix40/listcancelrequest/ListCancelRequest.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/listexecute/ListExecute.go
+++ b/fix40/listexecute/ListExecute.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/liststatus/ListStatus.go
+++ b/fix40/liststatus/ListStatus.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/liststatusrequest/ListStatusRequest.go
+++ b/fix40/liststatusrequest/ListStatusRequest.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/logon/Logon.go
+++ b/fix40/logon/Logon.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/logout/Logout.go
+++ b/fix40/logout/Logout.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/neworderlist/NewOrderList.go
+++ b/fix40/neworderlist/NewOrderList.go
@@ -99,7 +99,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/newordersingle/NewOrderSingle.go
+++ b/fix40/newordersingle/NewOrderSingle.go
@@ -93,7 +93,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/news/News.go
+++ b/fix40/news/News.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/ordercancelreject/OrderCancelReject.go
+++ b/fix40/ordercancelreject/OrderCancelReject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix40/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -89,7 +89,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/ordercancelrequest/OrderCancelRequest.go
+++ b/fix40/ordercancelrequest/OrderCancelRequest.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/orderstatusrequest/OrderStatusRequest.go
+++ b/fix40/orderstatusrequest/OrderStatusRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/quote/Quote.go
+++ b/fix40/quote/Quote.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/quoterequest/QuoteRequest.go
+++ b/fix40/quoterequest/QuoteRequest.go
@@ -40,7 +40,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/reject/Reject.go
+++ b/fix40/reject/Reject.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/resendrequest/ResendRequest.go
+++ b/fix40/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/sequencereset/SequenceReset.go
+++ b/fix40/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix40/testrequest/TestRequest.go
+++ b/fix40/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/advertisement/Advertisement.go
+++ b/fix41/advertisement/Advertisement.go
@@ -71,7 +71,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/allocation/Allocation.go
+++ b/fix41/allocation/Allocation.go
@@ -173,7 +173,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/allocationack/AllocationACK.go
+++ b/fix41/allocationack/AllocationACK.go
@@ -37,7 +37,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/dontknowtrade/DontKnowTrade.go
+++ b/fix41/dontknowtrade/DontKnowTrade.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/email/Email.go
+++ b/fix41/email/Email.go
@@ -77,7 +77,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/executionreport/ExecutionReport.go
+++ b/fix41/executionreport/ExecutionReport.go
@@ -139,7 +139,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/heartbeat/Heartbeat.go
+++ b/fix41/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/indicationofinterest/IndicationofInterest.go
+++ b/fix41/indicationofinterest/IndicationofInterest.go
@@ -83,7 +83,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/listcancelrequest/ListCancelRequest.go
+++ b/fix41/listcancelrequest/ListCancelRequest.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/listexecute/ListExecute.go
+++ b/fix41/listexecute/ListExecute.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/liststatus/ListStatus.go
+++ b/fix41/liststatus/ListStatus.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/liststatusrequest/ListStatusRequest.go
+++ b/fix41/liststatusrequest/ListStatusRequest.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/logon/Logon.go
+++ b/fix41/logon/Logon.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/logout/Logout.go
+++ b/fix41/logout/Logout.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/neworderlist/NewOrderList.go
+++ b/fix41/neworderlist/NewOrderList.go
@@ -127,7 +127,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/newordersingle/NewOrderSingle.go
+++ b/fix41/newordersingle/NewOrderSingle.go
@@ -123,7 +123,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/news/News.go
+++ b/fix41/news/News.go
@@ -73,7 +73,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/ordercancelreject/OrderCancelReject.go
+++ b/fix41/ordercancelreject/OrderCancelReject.go
@@ -40,7 +40,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix41/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -121,7 +121,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/ordercancelrequest/OrderCancelRequest.go
+++ b/fix41/ordercancelrequest/OrderCancelRequest.go
@@ -66,7 +66,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/orderstatusrequest/OrderStatusRequest.go
+++ b/fix41/orderstatusrequest/OrderStatusRequest.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/quote/Quote.go
+++ b/fix41/quote/Quote.go
@@ -79,7 +79,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/quoterequest/QuoteRequest.go
+++ b/fix41/quoterequest/QuoteRequest.go
@@ -62,7 +62,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/reject/Reject.go
+++ b/fix41/reject/Reject.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/resendrequest/ResendRequest.go
+++ b/fix41/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/sequencereset/SequenceReset.go
+++ b/fix41/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/settlementinstructions/SettlementInstructions.go
+++ b/fix41/settlementinstructions/SettlementInstructions.go
@@ -89,7 +89,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix41/testrequest/TestRequest.go
+++ b/fix41/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/advertisement/Advertisement.go
+++ b/fix42/advertisement/Advertisement.go
@@ -89,7 +89,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/allocation/Allocation.go
+++ b/fix42/allocation/Allocation.go
@@ -199,7 +199,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/allocationack/AllocationACK.go
+++ b/fix42/allocationack/AllocationACK.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/bidrequest/BidRequest.go
+++ b/fix42/bidrequest/BidRequest.go
@@ -123,7 +123,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/bidresponse/BidResponse.go
+++ b/fix42/bidresponse/BidResponse.go
@@ -60,7 +60,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/businessmessagereject/BusinessMessageReject.go
+++ b/fix42/businessmessagereject/BusinessMessageReject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/dontknowtrade/DontKnowTrade.go
+++ b/fix42/dontknowtrade/DontKnowTrade.go
@@ -80,7 +80,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/email/Email.go
+++ b/fix42/email/Email.go
@@ -107,7 +107,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/executionreport/ExecutionReport.go
+++ b/fix42/executionreport/ExecutionReport.go
@@ -217,7 +217,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/heartbeat/Heartbeat.go
+++ b/fix42/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/indicationofinterest/IndicationofInterest.go
+++ b/fix42/indicationofinterest/IndicationofInterest.go
@@ -111,7 +111,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/listcancelrequest/ListCancelRequest.go
+++ b/fix42/listcancelrequest/ListCancelRequest.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/listexecute/ListExecute.go
+++ b/fix42/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/liststatus/ListStatus.go
+++ b/fix42/liststatus/ListStatus.go
@@ -67,7 +67,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/liststatusrequest/ListStatusRequest.go
+++ b/fix42/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/liststrikeprice/ListStrikePrice.go
+++ b/fix42/liststrikeprice/ListStrikePrice.go
@@ -84,7 +84,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/logon/Logon.go
+++ b/fix42/logon/Logon.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/logout/Logout.go
+++ b/fix42/logout/Logout.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix42/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -141,7 +141,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/marketdatarequest/MarketDataRequest.go
+++ b/fix42/marketdatarequest/MarketDataRequest.go
@@ -84,7 +84,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix42/marketdatarequestreject/MarketDataRequestReject.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix42/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -133,7 +133,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/massquote/MassQuote.go
+++ b/fix42/massquote/MassQuote.go
@@ -159,7 +159,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/neworderlist/NewOrderList.go
+++ b/fix42/neworderlist/NewOrderList.go
@@ -211,7 +211,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/newordersingle/NewOrderSingle.go
+++ b/fix42/newordersingle/NewOrderSingle.go
@@ -177,7 +177,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/news/News.go
+++ b/fix42/news/News.go
@@ -103,7 +103,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/ordercancelreject/OrderCancelReject.go
+++ b/fix42/ordercancelreject/OrderCancelReject.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix42/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -175,7 +175,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/ordercancelrequest/OrderCancelRequest.go
+++ b/fix42/ordercancelrequest/OrderCancelRequest.go
@@ -91,7 +91,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/orderstatusrequest/OrderStatusRequest.go
+++ b/fix42/orderstatusrequest/OrderStatusRequest.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/quote/Quote.go
+++ b/fix42/quote/Quote.go
@@ -97,7 +97,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/quoteacknowledgement/QuoteAcknowledgement.go
+++ b/fix42/quoteacknowledgement/QuoteAcknowledgement.go
@@ -130,7 +130,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/quotecancel/QuoteCancel.go
+++ b/fix42/quotecancel/QuoteCancel.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/quoterequest/QuoteRequest.go
+++ b/fix42/quoterequest/QuoteRequest.go
@@ -91,7 +91,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix42/quotestatusrequest/QuoteStatusRequest.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/reject/Reject.go
+++ b/fix42/reject/Reject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/resendrequest/ResendRequest.go
+++ b/fix42/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/securitydefinition/SecurityDefinition.go
+++ b/fix42/securitydefinition/SecurityDefinition.go
@@ -126,7 +126,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix42/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -122,7 +122,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/securitystatus/SecurityStatus.go
+++ b/fix42/securitystatus/SecurityStatus.go
@@ -93,7 +93,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix42/securitystatusrequest/SecurityStatusRequest.go
@@ -66,7 +66,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/sequencereset/SequenceReset.go
+++ b/fix42/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/settlementinstructions/SettlementInstructions.go
+++ b/fix42/settlementinstructions/SettlementInstructions.go
@@ -93,7 +93,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/testrequest/TestRequest.go
+++ b/fix42/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix42/tradingsessionstatus/TradingSessionStatus.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix42/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix42/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/advertisement/Advertisement.go
+++ b/fix43/advertisement/Advertisement.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/allocation/Allocation.go
+++ b/fix43/allocation/Allocation.go
@@ -185,7 +185,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/allocationack/AllocationAck.go
+++ b/fix43/allocationack/AllocationAck.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/bidrequest/BidRequest.go
+++ b/fix43/bidrequest/BidRequest.go
@@ -125,7 +125,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/bidresponse/BidResponse.go
+++ b/fix43/bidresponse/BidResponse.go
@@ -61,7 +61,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/businessmessagereject/BusinessMessageReject.go
+++ b/fix43/businessmessagereject/BusinessMessageReject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
+++ b/fix43/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
@@ -207,7 +207,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/crossordercancelrequest/CrossOrderCancelRequest.go
+++ b/fix43/crossordercancelrequest/CrossOrderCancelRequest.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/derivativesecuritylist/DerivativeSecurityList.go
+++ b/fix43/derivativesecuritylist/DerivativeSecurityList.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
+++ b/fix43/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/dontknowtrade/DontKnowTrade.go
+++ b/fix43/dontknowtrade/DontKnowTrade.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/email/Email.go
+++ b/fix43/email/Email.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/executionreport/ExecutionReport.go
+++ b/fix43/executionreport/ExecutionReport.go
@@ -308,7 +308,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/heartbeat/Heartbeat.go
+++ b/fix43/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ioi/IOI.go
+++ b/fix43/ioi/IOI.go
@@ -81,7 +81,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/listcancelrequest/ListCancelRequest.go
+++ b/fix43/listcancelrequest/ListCancelRequest.go
@@ -33,7 +33,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/listexecute/ListExecute.go
+++ b/fix43/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/liststatus/ListStatus.go
+++ b/fix43/liststatus/ListStatus.go
@@ -71,7 +71,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/liststatusrequest/ListStatusRequest.go
+++ b/fix43/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/liststrikeprice/ListStrikePrice.go
+++ b/fix43/liststrikeprice/ListStrikePrice.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/logon/Logon.go
+++ b/fix43/logon/Logon.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/logout/Logout.go
+++ b/fix43/logout/Logout.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix43/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -116,7 +116,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/marketdatarequest/MarketDataRequest.go
+++ b/fix43/marketdatarequest/MarketDataRequest.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix43/marketdatarequestreject/MarketDataRequestReject.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix43/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -108,7 +108,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/massquote/MassQuote.go
+++ b/fix43/massquote/MassQuote.go
@@ -112,7 +112,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/massquoteacknowledgement/MassQuoteAcknowledgement.go
+++ b/fix43/massquoteacknowledgement/MassQuoteAcknowledgement.go
@@ -114,7 +114,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/multilegordercancelreplacerequest/MultilegOrderCancelReplaceRequest.go
+++ b/fix43/multilegordercancelreplacerequest/MultilegOrderCancelReplaceRequest.go
@@ -199,7 +199,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/newordercross/NewOrderCross.go
+++ b/fix43/newordercross/NewOrderCross.go
@@ -199,7 +199,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/neworderlist/NewOrderList.go
+++ b/fix43/neworderlist/NewOrderList.go
@@ -227,7 +227,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/newordermultileg/NewOrderMultileg.go
+++ b/fix43/newordermultileg/NewOrderMultileg.go
@@ -193,7 +193,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/newordersingle/NewOrderSingle.go
+++ b/fix43/newordersingle/NewOrderSingle.go
@@ -193,7 +193,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/news/News.go
+++ b/fix43/news/News.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordercancelreject/OrderCancelReject.go
+++ b/fix43/ordercancelreject/OrderCancelReject.go
@@ -59,7 +59,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix43/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -190,7 +190,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordercancelrequest/OrderCancelRequest.go
+++ b/fix43/ordercancelrequest/OrderCancelRequest.go
@@ -60,7 +60,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordermasscancelreport/OrderMassCancelReport.go
+++ b/fix43/ordermasscancelreport/OrderMassCancelReport.go
@@ -69,7 +69,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordermasscancelrequest/OrderMassCancelRequest.go
+++ b/fix43/ordermasscancelrequest/OrderMassCancelRequest.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/ordermassstatusrequest/OrderMassStatusRequest.go
+++ b/fix43/ordermassstatusrequest/OrderMassStatusRequest.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/orderstatusrequest/OrderStatusRequest.go
+++ b/fix43/orderstatusrequest/OrderStatusRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quote/Quote.go
+++ b/fix43/quote/Quote.go
@@ -115,7 +115,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quotecancel/QuoteCancel.go
+++ b/fix43/quotecancel/QuoteCancel.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quoterequest/QuoteRequest.go
+++ b/fix43/quoterequest/QuoteRequest.go
@@ -91,7 +91,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quoterequestreject/QuoteRequestReject.go
+++ b/fix43/quoterequestreject/QuoteRequestReject.go
@@ -93,7 +93,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quotestatusreport/QuoteStatusReport.go
+++ b/fix43/quotestatusreport/QuoteStatusReport.go
@@ -109,7 +109,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix43/quotestatusrequest/QuoteStatusRequest.go
@@ -40,7 +40,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/registrationinstructions/RegistrationInstructions.go
+++ b/fix43/registrationinstructions/RegistrationInstructions.go
@@ -82,7 +82,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/registrationinstructionsresponse/RegistrationInstructionsResponse.go
+++ b/fix43/registrationinstructionsresponse/RegistrationInstructionsResponse.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/reject/Reject.go
+++ b/fix43/reject/Reject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/resendrequest/ResendRequest.go
+++ b/fix43/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/rfqrequest/RFQRequest.go
+++ b/fix43/rfqrequest/RFQRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitydefinition/SecurityDefinition.go
+++ b/fix43/securitydefinition/SecurityDefinition.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix43/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitylist/SecurityList.go
+++ b/fix43/securitylist/SecurityList.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitylistrequest/SecurityListRequest.go
+++ b/fix43/securitylistrequest/SecurityListRequest.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitystatus/SecurityStatus.go
+++ b/fix43/securitystatus/SecurityStatus.go
@@ -66,7 +66,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix43/securitystatusrequest/SecurityStatusRequest.go
@@ -33,7 +33,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitytyperequest/SecurityTypeRequest.go
+++ b/fix43/securitytyperequest/SecurityTypeRequest.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/securitytypes/SecurityTypes.go
+++ b/fix43/securitytypes/SecurityTypes.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/sequencereset/SequenceReset.go
+++ b/fix43/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/settlementinstructions/SettlementInstructions.go
+++ b/fix43/settlementinstructions/SettlementInstructions.go
@@ -114,7 +114,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/testrequest/TestRequest.go
+++ b/fix43/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/tradecapturereport/TradeCaptureReport.go
+++ b/fix43/tradecapturereport/TradeCaptureReport.go
@@ -185,7 +185,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/tradecapturereportrequest/TradeCaptureReportRequest.go
+++ b/fix43/tradecapturereportrequest/TradeCaptureReportRequest.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix43/tradingsessionstatus/TradingSessionStatus.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix43/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix43/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/advertisement/Advertisement.go
+++ b/fix44/advertisement/Advertisement.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/allocationinstruction/AllocationInstruction.go
+++ b/fix44/allocationinstruction/AllocationInstruction.go
@@ -290,7 +290,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/allocationinstructionack/AllocationInstructionAck.go
+++ b/fix44/allocationinstructionack/AllocationInstructionAck.go
@@ -74,7 +74,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/allocationreport/AllocationReport.go
+++ b/fix44/allocationreport/AllocationReport.go
@@ -298,7 +298,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/allocationreportack/AllocationReportAck.go
+++ b/fix44/allocationreportack/AllocationReportAck.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/assignmentreport/AssignmentReport.go
+++ b/fix44/assignmentreport/AssignmentReport.go
@@ -92,7 +92,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/bidrequest/BidRequest.go
+++ b/fix44/bidrequest/BidRequest.go
@@ -127,7 +127,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/bidresponse/BidResponse.go
+++ b/fix44/bidresponse/BidResponse.go
@@ -61,7 +61,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/businessmessagereject/BusinessMessageReject.go
+++ b/fix44/businessmessagereject/BusinessMessageReject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralassignment/CollateralAssignment.go
+++ b/fix44/collateralassignment/CollateralAssignment.go
@@ -164,7 +164,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralinquiry/CollateralInquiry.go
+++ b/fix44/collateralinquiry/CollateralInquiry.go
@@ -149,7 +149,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralinquiryack/CollateralInquiryAck.go
+++ b/fix44/collateralinquiryack/CollateralInquiryAck.go
@@ -121,7 +121,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralreport/CollateralReport.go
+++ b/fix44/collateralreport/CollateralReport.go
@@ -157,7 +157,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralrequest/CollateralRequest.go
+++ b/fix44/collateralrequest/CollateralRequest.go
@@ -155,7 +155,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/collateralresponse/CollateralResponse.go
+++ b/fix44/collateralresponse/CollateralResponse.go
@@ -153,7 +153,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/confirmation/Confirmation.go
+++ b/fix44/confirmation/Confirmation.go
@@ -220,7 +220,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/confirmationack/ConfirmationAck.go
+++ b/fix44/confirmationack/ConfirmationAck.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/confirmationrequest/ConfirmationRequest.go
+++ b/fix44/confirmationrequest/ConfirmationRequest.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
+++ b/fix44/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
@@ -237,7 +237,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/crossordercancelrequest/CrossOrderCancelRequest.go
+++ b/fix44/crossordercancelrequest/CrossOrderCancelRequest.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/derivativesecuritylist/DerivativeSecurityList.go
+++ b/fix44/derivativesecuritylist/DerivativeSecurityList.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
+++ b/fix44/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/dontknowtrade/DontKnowTrade.go
+++ b/fix44/dontknowtrade/DontKnowTrade.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/email/Email.go
+++ b/fix44/email/Email.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/executionreport/ExecutionReport.go
+++ b/fix44/executionreport/ExecutionReport.go
@@ -381,7 +381,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/heartbeat/Heartbeat.go
+++ b/fix44/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ioi/IOI.go
+++ b/fix44/ioi/IOI.go
@@ -114,7 +114,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/listcancelrequest/ListCancelRequest.go
+++ b/fix44/listcancelrequest/ListCancelRequest.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/listexecute/ListExecute.go
+++ b/fix44/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/liststatus/ListStatus.go
+++ b/fix44/liststatus/ListStatus.go
@@ -73,7 +73,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/liststatusrequest/ListStatusRequest.go
+++ b/fix44/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/liststrikeprice/ListStrikePrice.go
+++ b/fix44/liststrikeprice/ListStrikePrice.go
@@ -62,7 +62,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/logon/Logon.go
+++ b/fix44/logon/Logon.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/logout/Logout.go
+++ b/fix44/logout/Logout.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix44/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -134,7 +134,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/marketdatarequest/MarketDataRequest.go
+++ b/fix44/marketdatarequest/MarketDataRequest.go
@@ -85,7 +85,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix44/marketdatarequestreject/MarketDataRequestReject.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix44/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -126,7 +126,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/massquote/MassQuote.go
+++ b/fix44/massquote/MassQuote.go
@@ -125,7 +125,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/massquoteacknowledgement/MassQuoteAcknowledgement.go
+++ b/fix44/massquoteacknowledgement/MassQuoteAcknowledgement.go
@@ -131,7 +131,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/multilegordercancelreplace/MultilegOrderCancelReplace.go
+++ b/fix44/multilegordercancelreplace/MultilegOrderCancelReplace.go
@@ -255,7 +255,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
+++ b/fix44/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
+++ b/fix44/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/newordercross/NewOrderCross.go
+++ b/fix44/newordercross/NewOrderCross.go
@@ -229,7 +229,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/neworderlist/NewOrderList.go
+++ b/fix44/neworderlist/NewOrderList.go
@@ -254,7 +254,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/newordermultileg/NewOrderMultileg.go
+++ b/fix44/newordermultileg/NewOrderMultileg.go
@@ -249,7 +249,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/newordersingle/NewOrderSingle.go
+++ b/fix44/newordersingle/NewOrderSingle.go
@@ -215,7 +215,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/news/News.go
+++ b/fix44/news/News.go
@@ -86,7 +86,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordercancelreject/OrderCancelReject.go
+++ b/fix44/ordercancelreject/OrderCancelReject.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix44/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -212,7 +212,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordercancelrequest/OrderCancelRequest.go
+++ b/fix44/ordercancelrequest/OrderCancelRequest.go
@@ -74,7 +74,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordermasscancelreport/OrderMassCancelReport.go
+++ b/fix44/ordermasscancelreport/OrderMassCancelReport.go
@@ -69,7 +69,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordermasscancelrequest/OrderMassCancelRequest.go
+++ b/fix44/ordermasscancelrequest/OrderMassCancelRequest.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/ordermassstatusrequest/OrderMassStatusRequest.go
+++ b/fix44/ordermassstatusrequest/OrderMassStatusRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/orderstatusrequest/OrderStatusRequest.go
+++ b/fix44/orderstatusrequest/OrderStatusRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/positionmaintenancereport/PositionMaintenanceReport.go
+++ b/fix44/positionmaintenancereport/PositionMaintenanceReport.go
@@ -101,7 +101,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/positionmaintenancerequest/PositionMaintenanceRequest.go
+++ b/fix44/positionmaintenancerequest/PositionMaintenanceRequest.go
@@ -98,7 +98,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/positionreport/PositionReport.go
+++ b/fix44/positionreport/PositionReport.go
@@ -98,7 +98,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quote/Quote.go
+++ b/fix44/quote/Quote.go
@@ -189,7 +189,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quotecancel/QuoteCancel.go
+++ b/fix44/quotecancel/QuoteCancel.go
@@ -71,7 +71,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quoterequest/QuoteRequest.go
+++ b/fix44/quoterequest/QuoteRequest.go
@@ -153,7 +153,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quoterequestreject/QuoteRequestReject.go
+++ b/fix44/quoterequestreject/QuoteRequestReject.go
@@ -149,7 +149,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quoteresponse/QuoteResponse.go
+++ b/fix44/quoteresponse/QuoteResponse.go
@@ -193,7 +193,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quotestatusreport/QuoteStatusReport.go
+++ b/fix44/quotestatusreport/QuoteStatusReport.go
@@ -184,7 +184,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix44/quotestatusrequest/QuoteStatusRequest.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/registrationinstructions/RegistrationInstructions.go
+++ b/fix44/registrationinstructions/RegistrationInstructions.go
@@ -86,7 +86,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/registrationinstructionsresponse/RegistrationInstructionsResponse.go
+++ b/fix44/registrationinstructionsresponse/RegistrationInstructionsResponse.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/reject/Reject.go
+++ b/fix44/reject/Reject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/requestforpositions/RequestForPositions.go
+++ b/fix44/requestforpositions/RequestForPositions.go
@@ -89,7 +89,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/requestforpositionsack/RequestForPositionsAck.go
+++ b/fix44/requestforpositionsack/RequestForPositionsAck.go
@@ -74,7 +74,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/resendrequest/ResendRequest.go
+++ b/fix44/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/rfqrequest/RFQRequest.go
+++ b/fix44/rfqrequest/RFQRequest.go
@@ -61,7 +61,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitydefinition/SecurityDefinition.go
+++ b/fix44/securitydefinition/SecurityDefinition.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix44/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitylist/SecurityList.go
+++ b/fix44/securitylist/SecurityList.go
@@ -100,7 +100,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitylistrequest/SecurityListRequest.go
+++ b/fix44/securitylistrequest/SecurityListRequest.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitystatus/SecurityStatus.go
+++ b/fix44/securitystatus/SecurityStatus.go
@@ -87,7 +87,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix44/securitystatusrequest/SecurityStatusRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitytyperequest/SecurityTypeRequest.go
+++ b/fix44/securitytyperequest/SecurityTypeRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/securitytypes/SecurityTypes.go
+++ b/fix44/securitytypes/SecurityTypes.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/sequencereset/SequenceReset.go
+++ b/fix44/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/settlementinstructionrequest/SettlementInstructionRequest.go
+++ b/fix44/settlementinstructionrequest/SettlementInstructionRequest.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/settlementinstructions/SettlementInstructions.go
+++ b/fix44/settlementinstructions/SettlementInstructions.go
@@ -89,7 +89,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/testrequest/TestRequest.go
+++ b/fix44/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradecapturereport/TradeCaptureReport.go
+++ b/fix44/tradecapturereport/TradeCaptureReport.go
@@ -350,7 +350,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradecapturereportack/TradeCaptureReportAck.go
+++ b/fix44/tradecapturereportack/TradeCaptureReportAck.go
@@ -145,7 +145,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradecapturereportrequest/TradeCaptureReportRequest.go
+++ b/fix44/tradecapturereportrequest/TradeCaptureReportRequest.go
@@ -119,7 +119,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
+++ b/fix44/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix44/tradingsessionstatus/TradingSessionStatus.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix44/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/userrequest/UserRequest.go
+++ b/fix44/userrequest/UserRequest.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix44/userresponse/UserResponse.go
+++ b/fix44/userresponse/UserResponse.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/adjustedpositionreport/AdjustedPositionReport.go
+++ b/fix50/adjustedpositionreport/AdjustedPositionReport.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/advertisement/Advertisement.go
+++ b/fix50/advertisement/Advertisement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/allocationinstruction/AllocationInstruction.go
+++ b/fix50/allocationinstruction/AllocationInstruction.go
@@ -180,7 +180,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/allocationinstructionack/AllocationInstructionAck.go
+++ b/fix50/allocationinstructionack/AllocationInstructionAck.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/allocationinstructionalert/AllocationInstructionAlert.go
+++ b/fix50/allocationinstructionalert/AllocationInstructionAlert.go
@@ -180,7 +180,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/allocationreport/AllocationReport.go
+++ b/fix50/allocationreport/AllocationReport.go
@@ -190,7 +190,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/allocationreportack/AllocationReportAck.go
+++ b/fix50/allocationreportack/AllocationReportAck.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/assignmentreport/AssignmentReport.go
+++ b/fix50/assignmentreport/AssignmentReport.go
@@ -82,7 +82,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/bidrequest/BidRequest.go
+++ b/fix50/bidrequest/BidRequest.go
@@ -81,7 +81,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/bidresponse/BidResponse.go
+++ b/fix50/bidresponse/BidResponse.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/businessmessagereject/BusinessMessageReject.go
+++ b/fix50/businessmessagereject/BusinessMessageReject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralassignment/CollateralAssignment.go
+++ b/fix50/collateralassignment/CollateralAssignment.go
@@ -127,7 +127,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralinquiry/CollateralInquiry.go
+++ b/fix50/collateralinquiry/CollateralInquiry.go
@@ -120,7 +120,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralinquiryack/CollateralInquiryAck.go
+++ b/fix50/collateralinquiryack/CollateralInquiryAck.go
@@ -92,7 +92,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralreport/CollateralReport.go
+++ b/fix50/collateralreport/CollateralReport.go
@@ -129,7 +129,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralrequest/CollateralRequest.go
+++ b/fix50/collateralrequest/CollateralRequest.go
@@ -118,7 +118,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/collateralresponse/CollateralResponse.go
+++ b/fix50/collateralresponse/CollateralResponse.go
@@ -122,7 +122,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/confirmation/Confirmation.go
+++ b/fix50/confirmation/Confirmation.go
@@ -166,7 +166,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/confirmationack/ConfirmationAck.go
+++ b/fix50/confirmationack/ConfirmationAck.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/confirmationrequest/ConfirmationRequest.go
+++ b/fix50/confirmationrequest/ConfirmationRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/contraryintentionreport/ContraryIntentionReport.go
+++ b/fix50/contraryintentionreport/ContraryIntentionReport.go
@@ -49,7 +49,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
+++ b/fix50/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
@@ -149,7 +149,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/crossordercancelrequest/CrossOrderCancelRequest.go
+++ b/fix50/crossordercancelrequest/CrossOrderCancelRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/derivativesecuritylist/DerivativeSecurityList.go
+++ b/fix50/derivativesecuritylist/DerivativeSecurityList.go
@@ -36,7 +36,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
+++ b/fix50/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/dontknowtrade/DontKnowTrade.go
+++ b/fix50/dontknowtrade/DontKnowTrade.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/email/Email.go
+++ b/fix50/email/Email.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/executionacknowledgement/ExecutionAcknowledgement.go
+++ b/fix50/executionacknowledgement/ExecutionAcknowledgement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/executionreport/ExecutionReport.go
+++ b/fix50/executionreport/ExecutionReport.go
@@ -358,7 +358,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ioi/IOI.go
+++ b/fix50/ioi/IOI.go
@@ -88,7 +88,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/listcancelrequest/ListCancelRequest.go
+++ b/fix50/listcancelrequest/ListCancelRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/listexecute/ListExecute.go
+++ b/fix50/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/liststatus/ListStatus.go
+++ b/fix50/liststatus/ListStatus.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/liststatusrequest/ListStatusRequest.go
+++ b/fix50/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/liststrikeprice/ListStrikePrice.go
+++ b/fix50/liststrikeprice/ListStrikePrice.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix50/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/marketdatarequest/MarketDataRequest.go
+++ b/fix50/marketdatarequest/MarketDataRequest.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix50/marketdatarequestreject/MarketDataRequestReject.go
@@ -33,7 +33,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix50/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -57,7 +57,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/massquote/MassQuote.go
+++ b/fix50/massquote/MassQuote.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/massquoteacknowledgement/MassQuoteAcknowledgement.go
+++ b/fix50/massquoteacknowledgement/MassQuoteAcknowledgement.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/multilegordercancelreplace/MultilegOrderCancelReplace.go
+++ b/fix50/multilegordercancelreplace/MultilegOrderCancelReplace.go
@@ -200,7 +200,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
+++ b/fix50/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
+++ b/fix50/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/newordercross/NewOrderCross.go
+++ b/fix50/newordercross/NewOrderCross.go
@@ -143,7 +143,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/neworderlist/NewOrderList.go
+++ b/fix50/neworderlist/NewOrderList.go
@@ -62,7 +62,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/newordermultileg/NewOrderMultileg.go
+++ b/fix50/newordermultileg/NewOrderMultileg.go
@@ -198,7 +198,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/newordersingle/NewOrderSingle.go
+++ b/fix50/newordersingle/NewOrderSingle.go
@@ -222,7 +222,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/news/News.go
+++ b/fix50/news/News.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordercancelreject/OrderCancelReject.go
+++ b/fix50/ordercancelreject/OrderCancelReject.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix50/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -215,7 +215,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordercancelrequest/OrderCancelRequest.go
+++ b/fix50/ordercancelrequest/OrderCancelRequest.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordermasscancelreport/OrderMassCancelReport.go
+++ b/fix50/ordermasscancelreport/OrderMassCancelReport.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordermasscancelrequest/OrderMassCancelRequest.go
+++ b/fix50/ordermasscancelrequest/OrderMassCancelRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/ordermassstatusrequest/OrderMassStatusRequest.go
+++ b/fix50/ordermassstatusrequest/OrderMassStatusRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/orderstatusrequest/OrderStatusRequest.go
+++ b/fix50/orderstatusrequest/OrderStatusRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/positionmaintenancereport/PositionMaintenanceReport.go
+++ b/fix50/positionmaintenancereport/PositionMaintenanceReport.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/positionmaintenancerequest/PositionMaintenanceRequest.go
+++ b/fix50/positionmaintenancerequest/PositionMaintenanceRequest.go
@@ -84,7 +84,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/positionreport/PositionReport.go
+++ b/fix50/positionreport/PositionReport.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quote/Quote.go
+++ b/fix50/quote/Quote.go
@@ -155,7 +155,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quotecancel/QuoteCancel.go
+++ b/fix50/quotecancel/QuoteCancel.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quoterequest/QuoteRequest.go
+++ b/fix50/quoterequest/QuoteRequest.go
@@ -37,7 +37,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quoterequestreject/QuoteRequestReject.go
+++ b/fix50/quoterequestreject/QuoteRequestReject.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quoteresponse/QuoteResponse.go
+++ b/fix50/quoteresponse/QuoteResponse.go
@@ -155,7 +155,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quotestatusreport/QuoteStatusReport.go
+++ b/fix50/quotestatusreport/QuoteStatusReport.go
@@ -155,7 +155,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix50/quotestatusrequest/QuoteStatusRequest.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/registrationinstructions/RegistrationInstructions.go
+++ b/fix50/registrationinstructions/RegistrationInstructions.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/registrationinstructionsresponse/RegistrationInstructionsResponse.go
+++ b/fix50/registrationinstructionsresponse/RegistrationInstructionsResponse.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/requestforpositions/RequestForPositions.go
+++ b/fix50/requestforpositions/RequestForPositions.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/requestforpositionsack/RequestForPositionsAck.go
+++ b/fix50/requestforpositionsack/RequestForPositionsAck.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/rfqrequest/RFQRequest.go
+++ b/fix50/rfqrequest/RFQRequest.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitydefinition/SecurityDefinition.go
+++ b/fix50/securitydefinition/SecurityDefinition.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix50/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -60,7 +60,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
+++ b/fix50/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
@@ -61,7 +61,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitylist/SecurityList.go
+++ b/fix50/securitylist/SecurityList.go
@@ -37,7 +37,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitylistrequest/SecurityListRequest.go
+++ b/fix50/securitylistrequest/SecurityListRequest.go
@@ -53,7 +53,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitylistupdatereport/SecurityListUpdateReport.go
+++ b/fix50/securitylistupdatereport/SecurityListUpdateReport.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitystatus/SecurityStatus.go
+++ b/fix50/securitystatus/SecurityStatus.go
@@ -77,7 +77,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix50/securitystatusrequest/SecurityStatusRequest.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitytyperequest/SecurityTypeRequest.go
+++ b/fix50/securitytyperequest/SecurityTypeRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/securitytypes/SecurityTypes.go
+++ b/fix50/securitytypes/SecurityTypes.go
@@ -45,7 +45,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/settlementinstructionrequest/SettlementInstructionRequest.go
+++ b/fix50/settlementinstructionrequest/SettlementInstructionRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/settlementinstructions/SettlementInstructions.go
+++ b/fix50/settlementinstructions/SettlementInstructions.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradecapturereport/TradeCaptureReport.go
+++ b/fix50/tradecapturereport/TradeCaptureReport.go
@@ -196,7 +196,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradecapturereportack/TradeCaptureReportAck.go
+++ b/fix50/tradecapturereportack/TradeCaptureReportAck.go
@@ -184,7 +184,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradecapturereportrequest/TradeCaptureReportRequest.go
+++ b/fix50/tradecapturereportrequest/TradeCaptureReportRequest.go
@@ -111,7 +111,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
+++ b/fix50/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradingsessionlist/TradingSessionList.go
+++ b/fix50/tradingsessionlist/TradingSessionList.go
@@ -25,7 +25,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradingsessionlistrequest/TradingSessionListRequest.go
+++ b/fix50/tradingsessionlistrequest/TradingSessionListRequest.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix50/tradingsessionstatus/TradingSessionStatus.go
@@ -58,7 +58,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix50/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/userrequest/UserRequest.go
+++ b/fix50/userrequest/UserRequest.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50/userresponse/UserResponse.go
+++ b/fix50/userresponse/UserResponse.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/adjustedpositionreport/AdjustedPositionReport.go
+++ b/fix50sp1/adjustedpositionreport/AdjustedPositionReport.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/advertisement/Advertisement.go
+++ b/fix50sp1/advertisement/Advertisement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/allocationinstruction/AllocationInstruction.go
+++ b/fix50sp1/allocationinstruction/AllocationInstruction.go
@@ -180,7 +180,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/allocationinstructionack/AllocationInstructionAck.go
+++ b/fix50sp1/allocationinstructionack/AllocationInstructionAck.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/allocationinstructionalert/AllocationInstructionAlert.go
+++ b/fix50sp1/allocationinstructionalert/AllocationInstructionAlert.go
@@ -180,7 +180,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/allocationreport/AllocationReport.go
+++ b/fix50sp1/allocationreport/AllocationReport.go
@@ -190,7 +190,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/allocationreportack/AllocationReportAck.go
+++ b/fix50sp1/allocationreportack/AllocationReportAck.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/applicationmessagereport/ApplicationMessageReport.go
+++ b/fix50sp1/applicationmessagereport/ApplicationMessageReport.go
@@ -33,7 +33,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/applicationmessagerequest/ApplicationMessageRequest.go
+++ b/fix50sp1/applicationmessagerequest/ApplicationMessageRequest.go
@@ -33,7 +33,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/applicationmessagerequestack/ApplicationMessageRequestAck.go
+++ b/fix50sp1/applicationmessagerequestack/ApplicationMessageRequestAck.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/assignmentreport/AssignmentReport.go
+++ b/fix50sp1/assignmentreport/AssignmentReport.go
@@ -85,7 +85,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/bidrequest/BidRequest.go
+++ b/fix50sp1/bidrequest/BidRequest.go
@@ -81,7 +81,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/bidresponse/BidResponse.go
+++ b/fix50sp1/bidresponse/BidResponse.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/businessmessagereject/BusinessMessageReject.go
+++ b/fix50sp1/businessmessagereject/BusinessMessageReject.go
@@ -40,7 +40,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralassignment/CollateralAssignment.go
+++ b/fix50sp1/collateralassignment/CollateralAssignment.go
@@ -127,7 +127,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralinquiry/CollateralInquiry.go
+++ b/fix50sp1/collateralinquiry/CollateralInquiry.go
@@ -120,7 +120,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralinquiryack/CollateralInquiryAck.go
+++ b/fix50sp1/collateralinquiryack/CollateralInquiryAck.go
@@ -92,7 +92,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralreport/CollateralReport.go
+++ b/fix50sp1/collateralreport/CollateralReport.go
@@ -129,7 +129,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralrequest/CollateralRequest.go
+++ b/fix50sp1/collateralrequest/CollateralRequest.go
@@ -118,7 +118,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/collateralresponse/CollateralResponse.go
+++ b/fix50sp1/collateralresponse/CollateralResponse.go
@@ -122,7 +122,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/confirmation/Confirmation.go
+++ b/fix50sp1/confirmation/Confirmation.go
@@ -166,7 +166,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/confirmationack/ConfirmationAck.go
+++ b/fix50sp1/confirmationack/ConfirmationAck.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/confirmationrequest/ConfirmationRequest.go
+++ b/fix50sp1/confirmationrequest/ConfirmationRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/contraryintentionreport/ContraryIntentionReport.go
+++ b/fix50sp1/contraryintentionreport/ContraryIntentionReport.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
+++ b/fix50sp1/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
@@ -149,7 +149,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/crossordercancelrequest/CrossOrderCancelRequest.go
+++ b/fix50sp1/crossordercancelrequest/CrossOrderCancelRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/derivativesecuritylist/DerivativeSecurityList.go
+++ b/fix50sp1/derivativesecuritylist/DerivativeSecurityList.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
+++ b/fix50sp1/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/derivativesecuritylistupdatereport/DerivativeSecurityListUpdateReport.go
+++ b/fix50sp1/derivativesecuritylistupdatereport/DerivativeSecurityListUpdateReport.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/dontknowtrade/DontKnowTrade.go
+++ b/fix50sp1/dontknowtrade/DontKnowTrade.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/email/Email.go
+++ b/fix50sp1/email/Email.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/executionacknowledgement/ExecutionAcknowledgement.go
+++ b/fix50sp1/executionacknowledgement/ExecutionAcknowledgement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/executionreport/ExecutionReport.go
+++ b/fix50sp1/executionreport/ExecutionReport.go
@@ -385,7 +385,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ioi/IOI.go
+++ b/fix50sp1/ioi/IOI.go
@@ -91,7 +91,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/listcancelrequest/ListCancelRequest.go
+++ b/fix50sp1/listcancelrequest/ListCancelRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/listexecute/ListExecute.go
+++ b/fix50sp1/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/liststatus/ListStatus.go
+++ b/fix50sp1/liststatus/ListStatus.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/liststatusrequest/ListStatusRequest.go
+++ b/fix50sp1/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/liststrikeprice/ListStrikePrice.go
+++ b/fix50sp1/liststrikeprice/ListStrikePrice.go
@@ -29,7 +29,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix50sp1/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdatarequest/MarketDataRequest.go
+++ b/fix50sp1/marketdatarequest/MarketDataRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix50sp1/marketdatarequestreject/MarketDataRequestReject.go
@@ -36,7 +36,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix50sp1/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdefinition/MarketDefinition.go
+++ b/fix50sp1/marketdefinition/MarketDefinition.go
@@ -62,7 +62,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdefinitionrequest/MarketDefinitionRequest.go
+++ b/fix50sp1/marketdefinitionrequest/MarketDefinitionRequest.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/marketdefinitionupdatereport/MarketDefinitionUpdateReport.go
+++ b/fix50sp1/marketdefinitionupdatereport/MarketDefinitionUpdateReport.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/massquote/MassQuote.go
+++ b/fix50sp1/massquote/MassQuote.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/massquoteacknowledgement/MassQuoteAcknowledgement.go
+++ b/fix50sp1/massquoteacknowledgement/MassQuoteAcknowledgement.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/multilegordercancelreplace/MultilegOrderCancelReplace.go
+++ b/fix50sp1/multilegordercancelreplace/MultilegOrderCancelReplace.go
@@ -206,7 +206,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
+++ b/fix50sp1/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
+++ b/fix50sp1/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/newordercross/NewOrderCross.go
+++ b/fix50sp1/newordercross/NewOrderCross.go
@@ -143,7 +143,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/neworderlist/NewOrderList.go
+++ b/fix50sp1/neworderlist/NewOrderList.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/newordermultileg/NewOrderMultileg.go
+++ b/fix50sp1/newordermultileg/NewOrderMultileg.go
@@ -204,7 +204,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/newordersingle/NewOrderSingle.go
+++ b/fix50sp1/newordersingle/NewOrderSingle.go
@@ -222,7 +222,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/news/News.go
+++ b/fix50sp1/news/News.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordercancelreject/OrderCancelReject.go
+++ b/fix50sp1/ordercancelreject/OrderCancelReject.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix50sp1/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -215,7 +215,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordercancelrequest/OrderCancelRequest.go
+++ b/fix50sp1/ordercancelrequest/OrderCancelRequest.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordermassactionreport/OrderMassActionReport.go
+++ b/fix50sp1/ordermassactionreport/OrderMassActionReport.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordermassactionrequest/OrderMassActionRequest.go
+++ b/fix50sp1/ordermassactionrequest/OrderMassActionRequest.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordermasscancelreport/OrderMassCancelReport.go
+++ b/fix50sp1/ordermasscancelreport/OrderMassCancelReport.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordermasscancelrequest/OrderMassCancelRequest.go
+++ b/fix50sp1/ordermasscancelrequest/OrderMassCancelRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/ordermassstatusrequest/OrderMassStatusRequest.go
+++ b/fix50sp1/ordermassstatusrequest/OrderMassStatusRequest.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/orderstatusrequest/OrderStatusRequest.go
+++ b/fix50sp1/orderstatusrequest/OrderStatusRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/positionmaintenancereport/PositionMaintenanceReport.go
+++ b/fix50sp1/positionmaintenancereport/PositionMaintenanceReport.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/positionmaintenancerequest/PositionMaintenanceRequest.go
+++ b/fix50sp1/positionmaintenancerequest/PositionMaintenanceRequest.go
@@ -84,7 +84,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/positionreport/PositionReport.go
+++ b/fix50sp1/positionreport/PositionReport.go
@@ -93,7 +93,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quote/Quote.go
+++ b/fix50sp1/quote/Quote.go
@@ -161,7 +161,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quotecancel/QuoteCancel.go
+++ b/fix50sp1/quotecancel/QuoteCancel.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quoterequest/QuoteRequest.go
+++ b/fix50sp1/quoterequest/QuoteRequest.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quoterequestreject/QuoteRequestReject.go
+++ b/fix50sp1/quoterequestreject/QuoteRequestReject.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quoteresponse/QuoteResponse.go
+++ b/fix50sp1/quoteresponse/QuoteResponse.go
@@ -163,7 +163,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quotestatusreport/QuoteStatusReport.go
+++ b/fix50sp1/quotestatusreport/QuoteStatusReport.go
@@ -163,7 +163,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix50sp1/quotestatusrequest/QuoteStatusRequest.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/registrationinstructions/RegistrationInstructions.go
+++ b/fix50sp1/registrationinstructions/RegistrationInstructions.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/registrationinstructionsresponse/RegistrationInstructionsResponse.go
+++ b/fix50sp1/registrationinstructionsresponse/RegistrationInstructionsResponse.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/requestforpositions/RequestForPositions.go
+++ b/fix50sp1/requestforpositions/RequestForPositions.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/requestforpositionsack/RequestForPositionsAck.go
+++ b/fix50sp1/requestforpositionsack/RequestForPositionsAck.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/rfqrequest/RFQRequest.go
+++ b/fix50sp1/rfqrequest/RFQRequest.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitydefinition/SecurityDefinition.go
+++ b/fix50sp1/securitydefinition/SecurityDefinition.go
@@ -67,7 +67,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix50sp1/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
+++ b/fix50sp1/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
@@ -69,7 +69,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitylist/SecurityList.go
+++ b/fix50sp1/securitylist/SecurityList.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitylistrequest/SecurityListRequest.go
+++ b/fix50sp1/securitylistrequest/SecurityListRequest.go
@@ -57,7 +57,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitylistupdatereport/SecurityListUpdateReport.go
+++ b/fix50sp1/securitylistupdatereport/SecurityListUpdateReport.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitystatus/SecurityStatus.go
+++ b/fix50sp1/securitystatus/SecurityStatus.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix50sp1/securitystatusrequest/SecurityStatusRequest.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitytyperequest/SecurityTypeRequest.go
+++ b/fix50sp1/securitytyperequest/SecurityTypeRequest.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/securitytypes/SecurityTypes.go
+++ b/fix50sp1/securitytypes/SecurityTypes.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/settlementinstructionrequest/SettlementInstructionRequest.go
+++ b/fix50sp1/settlementinstructionrequest/SettlementInstructionRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/settlementinstructions/SettlementInstructions.go
+++ b/fix50sp1/settlementinstructions/SettlementInstructions.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/settlementobligationreport/SettlementObligationReport.go
+++ b/fix50sp1/settlementobligationreport/SettlementObligationReport.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradecapturereport/TradeCaptureReport.go
+++ b/fix50sp1/tradecapturereport/TradeCaptureReport.go
@@ -220,7 +220,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradecapturereportack/TradeCaptureReportAck.go
+++ b/fix50sp1/tradecapturereportack/TradeCaptureReportAck.go
@@ -195,7 +195,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradecapturereportrequest/TradeCaptureReportRequest.go
+++ b/fix50sp1/tradecapturereportrequest/TradeCaptureReportRequest.go
@@ -111,7 +111,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
+++ b/fix50sp1/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradingsessionlist/TradingSessionList.go
+++ b/fix50sp1/tradingsessionlist/TradingSessionList.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradingsessionlistrequest/TradingSessionListRequest.go
+++ b/fix50sp1/tradingsessionlistrequest/TradingSessionListRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradingsessionlistupdatereport/TradingSessionListUpdateReport.go
+++ b/fix50sp1/tradingsessionlistupdatereport/TradingSessionListUpdateReport.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix50sp1/tradingsessionstatus/TradingSessionStatus.go
@@ -67,7 +67,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix50sp1/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/usernotification/UserNotification.go
+++ b/fix50sp1/usernotification/UserNotification.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/userrequest/UserRequest.go
+++ b/fix50sp1/userrequest/UserRequest.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp1/userresponse/UserResponse.go
+++ b/fix50sp1/userresponse/UserResponse.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/adjustedpositionreport/AdjustedPositionReport.go
+++ b/fix50sp2/adjustedpositionreport/AdjustedPositionReport.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/advertisement/Advertisement.go
+++ b/fix50sp2/advertisement/Advertisement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/allocationinstruction/AllocationInstruction.go
+++ b/fix50sp2/allocationinstruction/AllocationInstruction.go
@@ -183,7 +183,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/allocationinstructionack/AllocationInstructionAck.go
+++ b/fix50sp2/allocationinstructionack/AllocationInstructionAck.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/allocationinstructionalert/AllocationInstructionAlert.go
+++ b/fix50sp2/allocationinstructionalert/AllocationInstructionAlert.go
@@ -180,7 +180,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/allocationreport/AllocationReport.go
+++ b/fix50sp2/allocationreport/AllocationReport.go
@@ -193,7 +193,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/allocationreportack/AllocationReportAck.go
+++ b/fix50sp2/allocationreportack/AllocationReportAck.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/applicationmessagereport/ApplicationMessageReport.go
+++ b/fix50sp2/applicationmessagereport/ApplicationMessageReport.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/applicationmessagerequest/ApplicationMessageRequest.go
+++ b/fix50sp2/applicationmessagerequest/ApplicationMessageRequest.go
@@ -36,7 +36,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/applicationmessagerequestack/ApplicationMessageRequestAck.go
+++ b/fix50sp2/applicationmessagerequestack/ApplicationMessageRequestAck.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/assignmentreport/AssignmentReport.go
+++ b/fix50sp2/assignmentreport/AssignmentReport.go
@@ -87,7 +87,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/bidrequest/BidRequest.go
+++ b/fix50sp2/bidrequest/BidRequest.go
@@ -81,7 +81,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/bidresponse/BidResponse.go
+++ b/fix50sp2/bidresponse/BidResponse.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/businessmessagereject/BusinessMessageReject.go
+++ b/fix50sp2/businessmessagereject/BusinessMessageReject.go
@@ -40,7 +40,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralassignment/CollateralAssignment.go
+++ b/fix50sp2/collateralassignment/CollateralAssignment.go
@@ -127,7 +127,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralinquiry/CollateralInquiry.go
+++ b/fix50sp2/collateralinquiry/CollateralInquiry.go
@@ -120,7 +120,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralinquiryack/CollateralInquiryAck.go
+++ b/fix50sp2/collateralinquiryack/CollateralInquiryAck.go
@@ -92,7 +92,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralreport/CollateralReport.go
+++ b/fix50sp2/collateralreport/CollateralReport.go
@@ -129,7 +129,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralrequest/CollateralRequest.go
+++ b/fix50sp2/collateralrequest/CollateralRequest.go
@@ -118,7 +118,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/collateralresponse/CollateralResponse.go
+++ b/fix50sp2/collateralresponse/CollateralResponse.go
@@ -122,7 +122,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/confirmation/Confirmation.go
+++ b/fix50sp2/confirmation/Confirmation.go
@@ -166,7 +166,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/confirmationack/ConfirmationAck.go
+++ b/fix50sp2/confirmationack/ConfirmationAck.go
@@ -39,7 +39,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/confirmationrequest/ConfirmationRequest.go
+++ b/fix50sp2/confirmationrequest/ConfirmationRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/contraryintentionreport/ContraryIntentionReport.go
+++ b/fix50sp2/contraryintentionreport/ContraryIntentionReport.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
+++ b/fix50sp2/crossordercancelreplacerequest/CrossOrderCancelReplaceRequest.go
@@ -149,7 +149,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/crossordercancelrequest/CrossOrderCancelRequest.go
+++ b/fix50sp2/crossordercancelrequest/CrossOrderCancelRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/derivativesecuritylist/DerivativeSecurityList.go
+++ b/fix50sp2/derivativesecuritylist/DerivativeSecurityList.go
@@ -49,7 +49,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
+++ b/fix50sp2/derivativesecuritylistrequest/DerivativeSecurityListRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/derivativesecuritylistupdatereport/DerivativeSecurityListUpdateReport.go
+++ b/fix50sp2/derivativesecuritylistupdatereport/DerivativeSecurityListUpdateReport.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/dontknowtrade/DontKnowTrade.go
+++ b/fix50sp2/dontknowtrade/DontKnowTrade.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/email/Email.go
+++ b/fix50sp2/email/Email.go
@@ -56,7 +56,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/executionacknowledgement/ExecutionAcknowledgement.go
+++ b/fix50sp2/executionacknowledgement/ExecutionAcknowledgement.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/executionreport/ExecutionReport.go
+++ b/fix50sp2/executionreport/ExecutionReport.go
@@ -388,7 +388,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ioi/IOI.go
+++ b/fix50sp2/ioi/IOI.go
@@ -91,7 +91,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/listcancelrequest/ListCancelRequest.go
+++ b/fix50sp2/listcancelrequest/ListCancelRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/listexecute/ListExecute.go
+++ b/fix50sp2/listexecute/ListExecute.go
@@ -35,7 +35,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/liststatus/ListStatus.go
+++ b/fix50sp2/liststatus/ListStatus.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/liststatusrequest/ListStatusRequest.go
+++ b/fix50sp2/liststatusrequest/ListStatusRequest.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/liststrikeprice/ListStrikePrice.go
+++ b/fix50sp2/liststrikeprice/ListStrikePrice.go
@@ -29,7 +29,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
+++ b/fix50sp2/marketdataincrementalrefresh/MarketDataIncrementalRefresh.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdatarequest/MarketDataRequest.go
+++ b/fix50sp2/marketdatarequest/MarketDataRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdatarequestreject/MarketDataRequestReject.go
+++ b/fix50sp2/marketdatarequestreject/MarketDataRequestReject.go
@@ -36,7 +36,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
+++ b/fix50sp2/marketdatasnapshotfullrefresh/MarketDataSnapshotFullRefresh.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdefinition/MarketDefinition.go
+++ b/fix50sp2/marketdefinition/MarketDefinition.go
@@ -62,7 +62,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdefinitionrequest/MarketDefinitionRequest.go
+++ b/fix50sp2/marketdefinitionrequest/MarketDefinitionRequest.go
@@ -30,7 +30,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/marketdefinitionupdatereport/MarketDefinitionUpdateReport.go
+++ b/fix50sp2/marketdefinitionupdatereport/MarketDefinitionUpdateReport.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/massquote/MassQuote.go
+++ b/fix50sp2/massquote/MassQuote.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/massquoteacknowledgement/MassQuoteAcknowledgement.go
+++ b/fix50sp2/massquoteacknowledgement/MassQuoteAcknowledgement.go
@@ -55,7 +55,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/multilegordercancelreplace/MultilegOrderCancelReplace.go
+++ b/fix50sp2/multilegordercancelreplace/MultilegOrderCancelReplace.go
@@ -206,7 +206,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
+++ b/fix50sp2/networkcounterpartysystemstatusrequest/NetworkCounterpartySystemStatusRequest.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
+++ b/fix50sp2/networkcounterpartysystemstatusresponse/NetworkCounterpartySystemStatusResponse.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/newordercross/NewOrderCross.go
+++ b/fix50sp2/newordercross/NewOrderCross.go
@@ -143,7 +143,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/neworderlist/NewOrderList.go
+++ b/fix50sp2/neworderlist/NewOrderList.go
@@ -64,7 +64,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/newordermultileg/NewOrderMultileg.go
+++ b/fix50sp2/newordermultileg/NewOrderMultileg.go
@@ -204,7 +204,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/newordersingle/NewOrderSingle.go
+++ b/fix50sp2/newordersingle/NewOrderSingle.go
@@ -222,7 +222,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/news/News.go
+++ b/fix50sp2/news/News.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordercancelreject/OrderCancelReject.go
+++ b/fix50sp2/ordercancelreject/OrderCancelReject.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordercancelreplacerequest/OrderCancelReplaceRequest.go
+++ b/fix50sp2/ordercancelreplacerequest/OrderCancelReplaceRequest.go
@@ -215,7 +215,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordercancelrequest/OrderCancelRequest.go
+++ b/fix50sp2/ordercancelrequest/OrderCancelRequest.go
@@ -68,7 +68,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordermassactionreport/OrderMassActionReport.go
+++ b/fix50sp2/ordermassactionreport/OrderMassActionReport.go
@@ -73,7 +73,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordermassactionrequest/OrderMassActionRequest.go
+++ b/fix50sp2/ordermassactionrequest/OrderMassActionRequest.go
@@ -59,7 +59,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordermasscancelreport/OrderMassCancelReport.go
+++ b/fix50sp2/ordermasscancelreport/OrderMassCancelReport.go
@@ -75,7 +75,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordermasscancelrequest/OrderMassCancelRequest.go
+++ b/fix50sp2/ordermasscancelrequest/OrderMassCancelRequest.go
@@ -57,7 +57,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/ordermassstatusrequest/OrderMassStatusRequest.go
+++ b/fix50sp2/ordermassstatusrequest/OrderMassStatusRequest.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/orderstatusrequest/OrderStatusRequest.go
+++ b/fix50sp2/orderstatusrequest/OrderStatusRequest.go
@@ -48,7 +48,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/partydetailslistreport/PartyDetailsListReport.go
+++ b/fix50sp2/partydetailslistreport/PartyDetailsListReport.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/partydetailslistrequest/PartyDetailsListRequest.go
+++ b/fix50sp2/partydetailslistrequest/PartyDetailsListRequest.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/positionmaintenancereport/PositionMaintenanceReport.go
+++ b/fix50sp2/positionmaintenancereport/PositionMaintenanceReport.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/positionmaintenancerequest/PositionMaintenanceRequest.go
+++ b/fix50sp2/positionmaintenancerequest/PositionMaintenanceRequest.go
@@ -84,7 +84,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/positionreport/PositionReport.go
+++ b/fix50sp2/positionreport/PositionReport.go
@@ -97,7 +97,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quote/Quote.go
+++ b/fix50sp2/quote/Quote.go
@@ -170,7 +170,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quotecancel/QuoteCancel.go
+++ b/fix50sp2/quotecancel/QuoteCancel.go
@@ -51,7 +51,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quoterequest/QuoteRequest.go
+++ b/fix50sp2/quoterequest/QuoteRequest.go
@@ -50,7 +50,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quoterequestreject/QuoteRequestReject.go
+++ b/fix50sp2/quoterequestreject/QuoteRequestReject.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quoteresponse/QuoteResponse.go
+++ b/fix50sp2/quoteresponse/QuoteResponse.go
@@ -163,7 +163,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quotestatusreport/QuoteStatusReport.go
+++ b/fix50sp2/quotestatusreport/QuoteStatusReport.go
@@ -172,7 +172,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/quotestatusrequest/QuoteStatusRequest.go
+++ b/fix50sp2/quotestatusrequest/QuoteStatusRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/registrationinstructions/RegistrationInstructions.go
+++ b/fix50sp2/registrationinstructions/RegistrationInstructions.go
@@ -47,7 +47,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/registrationinstructionsresponse/RegistrationInstructionsResponse.go
+++ b/fix50sp2/registrationinstructionsresponse/RegistrationInstructionsResponse.go
@@ -41,7 +41,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/requestforpositions/RequestForPositions.go
+++ b/fix50sp2/requestforpositions/RequestForPositions.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/requestforpositionsack/RequestForPositionsAck.go
+++ b/fix50sp2/requestforpositionsack/RequestForPositionsAck.go
@@ -76,7 +76,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/rfqrequest/RFQRequest.go
+++ b/fix50sp2/rfqrequest/RFQRequest.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitydefinition/SecurityDefinition.go
+++ b/fix50sp2/securitydefinition/SecurityDefinition.go
@@ -70,7 +70,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitydefinitionrequest/SecurityDefinitionRequest.go
+++ b/fix50sp2/securitydefinitionrequest/SecurityDefinitionRequest.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
+++ b/fix50sp2/securitydefinitionupdatereport/SecurityDefinitionUpdateReport.go
@@ -72,7 +72,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitylist/SecurityList.go
+++ b/fix50sp2/securitylist/SecurityList.go
@@ -61,7 +61,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitylistrequest/SecurityListRequest.go
+++ b/fix50sp2/securitylistrequest/SecurityListRequest.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitylistupdatereport/SecurityListUpdateReport.go
+++ b/fix50sp2/securitylistupdatereport/SecurityListUpdateReport.go
@@ -65,7 +65,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitystatus/SecurityStatus.go
+++ b/fix50sp2/securitystatus/SecurityStatus.go
@@ -90,7 +90,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitystatusrequest/SecurityStatusRequest.go
+++ b/fix50sp2/securitystatusrequest/SecurityStatusRequest.go
@@ -46,7 +46,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitytyperequest/SecurityTypeRequest.go
+++ b/fix50sp2/securitytyperequest/SecurityTypeRequest.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/securitytypes/SecurityTypes.go
+++ b/fix50sp2/securitytypes/SecurityTypes.go
@@ -52,7 +52,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/settlementinstructionrequest/SettlementInstructionRequest.go
+++ b/fix50sp2/settlementinstructionrequest/SettlementInstructionRequest.go
@@ -54,7 +54,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/settlementinstructions/SettlementInstructions.go
+++ b/fix50sp2/settlementinstructions/SettlementInstructions.go
@@ -42,7 +42,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/settlementobligationreport/SettlementObligationReport.go
+++ b/fix50sp2/settlementobligationreport/SettlementObligationReport.go
@@ -43,7 +43,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/streamassignmentreport/StreamAssignmentReport.go
+++ b/fix50sp2/streamassignmentreport/StreamAssignmentReport.go
@@ -29,7 +29,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/streamassignmentreportack/StreamAssignmentReportACK.go
+++ b/fix50sp2/streamassignmentreportack/StreamAssignmentReportACK.go
@@ -32,7 +32,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/streamassignmentrequest/StreamAssignmentRequest.go
+++ b/fix50sp2/streamassignmentrequest/StreamAssignmentRequest.go
@@ -27,7 +27,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradecapturereport/TradeCaptureReport.go
+++ b/fix50sp2/tradecapturereport/TradeCaptureReport.go
@@ -219,7 +219,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradecapturereportack/TradeCaptureReportAck.go
+++ b/fix50sp2/tradecapturereportack/TradeCaptureReportAck.go
@@ -199,7 +199,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradecapturereportrequest/TradeCaptureReportRequest.go
+++ b/fix50sp2/tradecapturereportrequest/TradeCaptureReportRequest.go
@@ -111,7 +111,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
+++ b/fix50sp2/tradecapturereportrequestack/TradeCaptureReportRequestAck.go
@@ -63,7 +63,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradingsessionlist/TradingSessionList.go
+++ b/fix50sp2/tradingsessionlist/TradingSessionList.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradingsessionlistrequest/TradingSessionListRequest.go
+++ b/fix50sp2/tradingsessionlistrequest/TradingSessionListRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradingsessionlistupdatereport/TradingSessionListUpdateReport.go
+++ b/fix50sp2/tradingsessionlistupdatereport/TradingSessionListUpdateReport.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradingsessionstatus/TradingSessionStatus.go
+++ b/fix50sp2/tradingsessionstatus/TradingSessionStatus.go
@@ -67,7 +67,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/tradingsessionstatusrequest/TradingSessionStatusRequest.go
+++ b/fix50sp2/tradingsessionstatusrequest/TradingSessionStatusRequest.go
@@ -38,7 +38,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/usernotification/UserNotification.go
+++ b/fix50sp2/usernotification/UserNotification.go
@@ -31,7 +31,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/userrequest/UserRequest.go
+++ b/fix50sp2/userrequest/UserRequest.go
@@ -44,7 +44,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fix50sp2/userresponse/UserResponse.go
+++ b/fix50sp2/userresponse/UserResponse.go
@@ -28,7 +28,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/heartbeat/Heartbeat.go
+++ b/fixt11/heartbeat/Heartbeat.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/logon/Logon.go
+++ b/fixt11/logon/Logon.go
@@ -45,7 +45,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/logout/Logout.go
+++ b/fixt11/logout/Logout.go
@@ -26,7 +26,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/reject/Reject.go
+++ b/fixt11/reject/Reject.go
@@ -34,7 +34,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/resendrequest/ResendRequest.go
+++ b/fixt11/resendrequest/ResendRequest.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/sequencereset/SequenceReset.go
+++ b/fixt11/sequencereset/SequenceReset.go
@@ -24,7 +24,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/fixt11/testrequest/TestRequest.go
+++ b/fixt11/testrequest/TestRequest.go
@@ -22,7 +22,7 @@ func (m Message) Marshal() quickfix.Message { return quickfix.Marshal(m) }
 //A RouteOut is the callback type that should be implemented for routing Message
 type RouteOut func(msg Message, sessionID quickfix.SessionID) quickfix.MessageRejectError
 
-//Route returns the beginstring, message type, and MessageRoute for this Mesage type
+//Route returns the beginstring, message type, and MessageRoute for this Message type
 func Route(router RouteOut) (string, string, quickfix.MessageRoute) {
 	r := func(msg quickfix.Message, sessionID quickfix.SessionID) quickfix.MessageRejectError {
 		m := new(Message)

--- a/message_router.go
+++ b/message_router.go
@@ -9,7 +9,7 @@ type routeKey struct {
 	MsgType     string
 }
 
-//A MessageRoute is a function can process a fromApp/fromAdmin callback
+//A MessageRoute is a function that can process a fromApp/fromAdmin callback
 type MessageRoute func(msg Message, sessionID SessionID) MessageRejectError
 
 //A MessageRouter is a mutex for MessageRoutes


### PR DESCRIPTION
Hi, this PR includes only fix to typos, grammar improvements for the `quickfix` package documentation, and code generation.

The code generation was necessary because one of the typos was in `_gen/generate-messages/main.go`.

I've added all the info in the commit messages.

I've ran all the tests, including `make accept`, all tests passed.

I hope this is helpful to the project. I'm really impressed with it and would love to join you in contributing.