### PR TITLE
Add sql database impl of MessageStore

### DIFF
--- a/_sql/mssql/create.bat
+++ b/_sql/mssql/create.bat
@@ -1,0 +1,1 @@
+osql -U sa -P -i quickfix_database.sql

--- a/_sql/mssql/quickfix_database.sql
+++ b/_sql/mssql/quickfix_database.sql
@@ -1,0 +1,65 @@
+DROP DATABASE quickfix;
+CREATE DATABASE quickfix;
+
+USE quickfix;
+CREATE TABLE sessions (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  creation_time DATETIME NOT NULL,
+  incoming_seqnum INT NOT NULL,
+  outgoing_seqnum INT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier)
+);
+
+CREATE TABLE messages (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  msgseqnum INT NOT NULL,
+  message TEXT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier,
+  				msgseqnum)
+);
+
+CREATE TABLE event_log (
+  id INT NOT NULL IDENTITY,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE messages_log (
+  id INT NOT NULL IDENTITY,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/_sql/mysql/create.bat
+++ b/_sql/mysql/create.bat
@@ -1,0 +1,1 @@
+mysql -u root --execute="source mysql.sql";

--- a/_sql/mysql/create.sh
+++ b/_sql/mysql/create.sh
@@ -1,0 +1,1 @@
+mysql -u root --execute="source mysql.sql";

--- a/_sql/mysql/event_log_table.sql
+++ b/_sql/mysql/event_log_table.sql
@@ -1,0 +1,18 @@
+USE quickfix;
+
+DROP TABLE IF EXISTS event_log;
+
+CREATE TABLE event_log (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64),
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/_sql/mysql/messages_log_table.sql
+++ b/_sql/mysql/messages_log_table.sql
@@ -1,0 +1,18 @@
+USE quickfix;
+
+DROP TABLE IF EXISTS messages_log;
+
+CREATE TABLE messages_log (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/_sql/mysql/messages_table.sql
+++ b/_sql/mysql/messages_table.sql
@@ -1,0 +1,19 @@
+USE quickfix;
+
+DROP TABLE IF EXISTS messages;
+
+CREATE TABLE messages (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  msgseqnum INT NOT NULL, 
+  message TEXT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier,
+  				msgseqnum)
+);

--- a/_sql/mysql/mysql.sql
+++ b/_sql/mysql/mysql.sql
@@ -1,0 +1,5 @@
+source quickfix_database.sql;
+source sessions_table.sql;
+source messages_table.sql;
+source messages_log_table.sql;
+source event_log_table.sql;

--- a/_sql/mysql/quickfix_database.sql
+++ b/_sql/mysql/quickfix_database.sql
@@ -1,0 +1,2 @@
+DROP DATABASE IF EXISTS quickfix;
+CREATE DATABASE quickfix;

--- a/_sql/mysql/sessions_table.sql
+++ b/_sql/mysql/sessions_table.sql
@@ -1,0 +1,19 @@
+USE quickfix;
+
+DROP TABLE IF EXISTS sessions;
+
+CREATE TABLE sessions (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  creation_time DATETIME NOT NULL,
+  incoming_seqnum INT NOT NULL, 
+  outgoing_seqnum INT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier)
+);

--- a/_sql/oracle/messages_table.sql
+++ b/_sql/oracle/messages_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE messages (
+  beginstring VARCHAR2(8) NOT NULL,
+  sendercompid VARCHAR2(64) NOT NULL,
+  sendersubid VARCHAR2(64) NOT NULL,
+  senderlocid VARCHAR2(64) NOT NULL,
+  targetcompid VARCHAR2(64) NOT NULL,
+  targetsubid VARCHAR2(64) NOT NULL,
+  targetlocid VARCHAR2(64) NOT NULL,
+  session_qualifier VARCHAR2(64) NOT NULL,
+  msgseqnum INTEGER NOT NULL, 
+  message VARCHAR2(4000) NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier, msgseqnum)
+);

--- a/_sql/oracle/sessions_table.sql
+++ b/_sql/oracle/sessions_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE sessions (
+  beginstring VARCHAR2(8) NOT NULL,
+  sendercompid VARCHAR2(64) NOT NULL,
+  sendersubid VARCHAR2(64) NOT NULL,
+  senderlocid VARCHAR2(64) NOT NULL,
+  targetcompid VARCHAR2(64) NOT NULL,
+  targetsubid VARCHAR2(64) NOT NULL,
+  targetlocid VARCHAR2(64) NOT NULL,
+  session_qualifier VARCHAR2(64) NOT NULL,
+  creation_time TIMESTAMP NOT NULL,
+  incoming_seqnum INTEGER NOT NULL, 
+  outgoing_seqnum INTEGER NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier)
+);

--- a/_sql/postgresql/create.bat
+++ b/_sql/postgresql/create.bat
@@ -1,0 +1,3 @@
+dropdb -U postgres -q quickfix
+createdb -U postgres quickfix
+psql -U postgres -d quickfix -f postgresql.sql

--- a/_sql/postgresql/create.sh
+++ b/_sql/postgresql/create.sh
@@ -1,0 +1,3 @@
+dropdb -U postgres -q quickfix
+createdb -U postgres quickfix
+psql -U postgres -d quickfix -f postgresql.sql

--- a/_sql/postgresql/event_log_table.sql
+++ b/_sql/postgresql/event_log_table.sql
@@ -1,0 +1,16 @@
+CREATE SEQUENCE event_log_sequence;
+
+CREATE TABLE event_log (
+  id INTEGER DEFAULT NEXTVAL('event_log_sequence'),
+  time TIMESTAMP NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64),
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/_sql/postgresql/messages_log_table.sql
+++ b/_sql/postgresql/messages_log_table.sql
@@ -1,0 +1,16 @@
+CREATE SEQUENCE messages_log_sequence;
+
+CREATE TABLE messages_log (
+  id INTEGER DEFAULT NEXTVAL('messages_log_sequence'),
+  time TIMESTAMP NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64),
+  text TEXT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/_sql/postgresql/messages_table.sql
+++ b/_sql/postgresql/messages_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE messages (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  msgseqnum INTEGER NOT NULL, 
+  message TEXT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier,
+  				msgseqnum)
+);

--- a/_sql/postgresql/postgresql.sql
+++ b/_sql/postgresql/postgresql.sql
@@ -1,0 +1,4 @@
+\i sessions_table.sql;
+\i messages_table.sql;
+\i messages_log_table.sql;
+\i event_log_table.sql;

--- a/_sql/postgresql/sessions_table.sql
+++ b/_sql/postgresql/sessions_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE sessions (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  creation_time TIMESTAMP NOT NULL,
+  incoming_seqnum INTEGER NOT NULL, 
+  outgoing_seqnum INTEGER NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier)
+);

--- a/_sql/sqlite3/event_log_table.sql
+++ b/_sql/sqlite3/event_log_table.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS event_log;
+
+CREATE TABLE event_log (
+  id INTEGER PRIMARY KEY NOT NULL,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64),
+  text TEXT NOT NULL
+);

--- a/_sql/sqlite3/messages_log_table.sql
+++ b/_sql/sqlite3/messages_log_table.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS messages_log;
+
+CREATE TABLE messages_log (
+  id INTEGER PRIMARY KEY NOT NULL,
+  time DATETIME NOT NULL,
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  text TEXT NOT NULL
+);

--- a/_sql/sqlite3/messages_table.sql
+++ b/_sql/sqlite3/messages_table.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS messages;
+
+CREATE TABLE messages (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  msgseqnum INT NOT NULL, 
+  message TEXT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier,
+  				msgseqnum)
+);

--- a/_sql/sqlite3/sessions_table.sql
+++ b/_sql/sqlite3/sessions_table.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS sessions;
+
+CREATE TABLE sessions (
+  beginstring CHAR(8) NOT NULL,
+  sendercompid VARCHAR(64) NOT NULL,
+  sendersubid VARCHAR(64) NOT NULL,
+  senderlocid VARCHAR(64) NOT NULL,
+  targetcompid VARCHAR(64) NOT NULL,
+  targetsubid VARCHAR(64) NOT NULL,
+  targetlocid VARCHAR(64) NOT NULL,
+  session_qualifier VARCHAR(64) NOT NULL,
+  creation_time DATETIME NOT NULL,
+  incoming_seqnum INT NOT NULL, 
+  outgoing_seqnum INT NOT NULL,
+  PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 
+  				targetcompid, targetsubid, targetlocid, session_qualifier)
+);

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -16,4 +16,6 @@ const (
 	HeartBtInt              string = "HeartBtInt"
 	FileLogPath             string = "FileLogPath"
 	FileStorePath           string = "FileStorePath"
+	SQLDriver               string = "SQLDriver"
+	SQLDataSourceName       string = "SQLDataSourceName"
 )

--- a/config/doc.go
+++ b/config/doc.go
@@ -122,5 +122,13 @@ Directory to store logs.	Value must be valid directory for storing files, applic
 FileStorePath
 
 Directory to store sequence number and message files.  Only used with FileStoreFactory.
+
+SQLDriver
+
+The name of the database driver to use (see https://github.com/golang/go/wiki/SQLDrivers for the list of available drivers).  Only used with SqlStoreFactory.
+
+SQLDataSourceName
+
+The driver-specific data source name of the database to use.  Only used with SqlStoreFactory.
 */
 package config

--- a/sqlstore.go
+++ b/sqlstore.go
@@ -89,7 +89,7 @@ func (store *sqlStore) Reset() error {
 	return err
 }
 
-// Refresh closes the store sqls and then reloads from them
+// Refresh reloads the store from the database
 func (store *sqlStore) Refresh() error {
 	if err := store.cache.Reset(); err != nil {
 		return err

--- a/sqlstore.go
+++ b/sqlstore.go
@@ -1,0 +1,261 @@
+package quickfix
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/quickfixgo/quickfix/config"
+)
+
+type sqlStoreFactory struct {
+	settings *SessionSettings
+}
+
+type sqlStore struct {
+	sessionID         SessionID
+	cache             *memoryStore
+	sqlDriver         string
+	sqlDataSourceName string
+	db                *sql.DB
+}
+
+// NewSQLStoreFactory returns a sql-based implementation of MessageStoreFactory
+func NewSQLStoreFactory(settings *SessionSettings) MessageStoreFactory {
+	return sqlStoreFactory{settings: settings}
+}
+
+// Create creates a new SQLStore implementation of the MessageStore interface
+func (f sqlStoreFactory) Create(sessionID SessionID) (msgStore MessageStore, err error) {
+	sqlDriver, err := f.settings.Setting(config.SQLDriver)
+	if err != nil {
+		return nil, err
+	}
+	sqlDataSourceName, err := f.settings.Setting(config.SQLDataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return newSQLStore(sessionID, sqlDriver, sqlDataSourceName)
+}
+
+func newSQLStore(sessionID SessionID, driver string, dataSourceName string) (store *sqlStore, err error) {
+	store = &sqlStore{
+		sessionID:         sessionID,
+		cache:             &memoryStore{},
+		sqlDriver:         driver,
+		sqlDataSourceName: dataSourceName,
+	}
+
+	if store.db, err = sql.Open(store.sqlDriver, store.sqlDataSourceName); err != nil {
+		return nil, err
+	}
+	if err = store.db.Ping(); err != nil { // ensure immediate connection
+		return nil, err
+	}
+	if err = store.populateCache(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// Reset deletes the store records and sets the seqnums back to 1
+func (store *sqlStore) Reset() error {
+	s := store.sessionID
+	_, err := store.db.Exec(`DELETE FROM messages
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?`,
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+	if err != nil {
+		return err
+	}
+
+	if err = store.cache.Reset(); err != nil {
+		return err
+	}
+
+	_, err = store.db.Exec(`UPDATE sessions
+		SET creation_time=?, incoming_seqnum=?, outgoing_seqnum=?
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?`,
+		store.cache.CreationTime(), store.cache.NextTargetMsgSeqNum(), store.cache.NextSenderMsgSeqNum(),
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+
+	return err
+}
+
+// Refresh closes the store sqls and then reloads from them
+func (store *sqlStore) Refresh() error {
+	if err := store.cache.Reset(); err != nil {
+		return err
+	}
+	return store.populateCache()
+}
+
+func (store *sqlStore) populateCache() (err error) {
+	s := store.sessionID
+	var creationTime time.Time
+	var incomingSeqNum, outgoingSeqNum int
+	row := store.db.QueryRow(`SELECT creation_time, incoming_seqnum, outgoing_seqnum
+	  FROM sessions
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?`,
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+
+	err = row.Scan(&creationTime, &incomingSeqNum, &outgoingSeqNum)
+
+	// session record found, load it
+	if err == nil {
+		store.cache.creationTime = creationTime
+		store.cache.SetNextTargetMsgSeqNum(incomingSeqNum)
+		store.cache.SetNextSenderMsgSeqNum(outgoingSeqNum)
+		return nil
+	}
+
+	// fatal error, give up
+	if err != sql.ErrNoRows {
+		return err
+	}
+
+	// session record not found, create it
+	_, err = store.db.Exec(`INSERT INTO sessions (
+			creation_time, incoming_seqnum, outgoing_seqnum,
+			beginstring, session_qualifier,
+			sendercompid, sendersubid, senderlocid,
+			targetcompid, targetsubid, targetlocid)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		store.cache.creationTime,
+		store.cache.NextTargetMsgSeqNum(),
+		store.cache.NextSenderMsgSeqNum(),
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+
+	return err
+}
+
+// NextSenderMsgSeqNum returns the next MsgSeqNum that will be sent
+func (store *sqlStore) NextSenderMsgSeqNum() int {
+	return store.cache.NextSenderMsgSeqNum()
+}
+
+// NextTargetMsgSeqNum returns the next MsgSeqNum that should be received
+func (store *sqlStore) NextTargetMsgSeqNum() int {
+	return store.cache.NextTargetMsgSeqNum()
+}
+
+// SetNextSenderMsgSeqNum sets the next MsgSeqNum that will be sent
+func (store *sqlStore) SetNextSenderMsgSeqNum(next int) error {
+	s := store.sessionID
+	_, err := store.db.Exec(`UPDATE sessions SET outgoing_seqnum = ?
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?`,
+		next, s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+	if err != nil {
+		return err
+	}
+	return store.cache.SetNextSenderMsgSeqNum(next)
+}
+
+// SetNextTargetMsgSeqNum sets the next MsgSeqNum that should be received
+func (store *sqlStore) SetNextTargetMsgSeqNum(next int) error {
+	s := store.sessionID
+	_, err := store.db.Exec(`UPDATE sessions SET incoming_seqnum = ?
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?`,
+		next, s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+	if err != nil {
+		return err
+	}
+	return store.cache.SetNextTargetMsgSeqNum(next)
+}
+
+// IncrNextSenderMsgSeqNum increments the next MsgSeqNum that will be sent
+func (store *sqlStore) IncrNextSenderMsgSeqNum() error {
+	store.cache.IncrNextSenderMsgSeqNum()
+	return store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum())
+}
+
+// IncrNextTargetMsgSeqNum increments the next MsgSeqNum that should be received
+func (store *sqlStore) IncrNextTargetMsgSeqNum() error {
+	store.cache.IncrNextTargetMsgSeqNum()
+	return store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum())
+}
+
+// CreationTime returns the creation time of the store
+func (store *sqlStore) CreationTime() time.Time {
+	return store.cache.CreationTime()
+}
+
+func (store *sqlStore) SaveMessage(seqNum int, msg []byte) error {
+	s := store.sessionID
+
+	_, err := store.db.Exec(`INSERT INTO messages (
+			msgseqnum, message,
+			beginstring, session_qualifier,
+			sendercompid, sendersubid, senderlocid,
+			targetcompid, targetsubid, targetlocid)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		seqNum, string(msg),
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID)
+
+	return err
+}
+
+func (store *sqlStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) {
+	s := store.sessionID
+	var msgs [][]byte
+	rows, err := store.db.Query(`SELECT message FROM messages
+		WHERE beginstring=? AND session_qualifier=?
+		AND sendercompid=? AND sendersubid=? AND senderlocid=?
+		AND targetcompid=? AND targetsubid=? AND targetlocid=?
+		AND msgseqnum>=? AND msgseqnum<=?
+		ORDER BY msgseqnum`,
+		s.BeginString, s.Qualifier,
+		s.SenderCompID, s.SenderSubID, s.SenderLocationID,
+		s.TargetCompID, s.TargetSubID, s.TargetLocationID,
+		beginSeqNum, endSeqNum)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var message string
+		if err := rows.Scan(&message); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, []byte(message))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return msgs, nil
+}
+
+// Close closes the store's database connection
+func (store *sqlStore) Close() error {
+	if store.db != nil {
+		store.db.Close()
+		store.db = nil
+	}
+	return nil
+}

--- a/sqlstore_test.go
+++ b/sqlstore_test.go
@@ -1,0 +1,59 @@
+package quickfix
+
+import (
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/quickfixgo/quickfix/config"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// SqlStoreTestSuite runs all tests in the MessageStoreTestSuite against the SqlStore implementation
+type SQLStoreTestSuite struct {
+	MessageStoreTestSuite
+	sqlStoreRootPath string
+}
+
+func (suite *SQLStoreTestSuite) SetupTest() {
+	suite.sqlStoreRootPath = path.Join(os.TempDir(), fmt.Sprintf("SqlStoreTestSuite-%d", os.Getpid()))
+	err := os.MkdirAll(suite.sqlStoreRootPath, os.ModePerm)
+	require.Nil(suite.T(), err)
+	sqlDriver := "sqlite3"
+	sqlDsn := path.Join(suite.sqlStoreRootPath, fmt.Sprintf("%d.db", time.Now().UnixNano()))
+
+	// create tables
+	db, err := sql.Open(sqlDriver, sqlDsn)
+	require.Nil(suite.T(), err)
+	ddlFnames, err := filepath.Glob(fmt.Sprintf("_sql/%s/*.sql", sqlDriver))
+	require.Nil(suite.T(), err)
+	for _, fname := range ddlFnames {
+		sqlBytes, err := ioutil.ReadFile(fname)
+		require.Nil(suite.T(), err)
+		_, err = db.Exec(string(sqlBytes))
+		require.Nil(suite.T(), err)
+	}
+
+	// create store
+	settings := NewSessionSettings()
+	settings.Set(config.SQLDataSourceName, sqlDsn)
+	settings.Set(config.SQLDriver, sqlDriver)
+	suite.msgStore, err = NewSQLStoreFactory(settings).Create(SessionID{BeginString: "FIX.4.4", SenderCompID: "SENDER", TargetCompID: "TARGET"})
+	require.Nil(suite.T(), err)
+}
+
+func (suite *SQLStoreTestSuite) TearDownTest() {
+	suite.msgStore.Close()
+	os.RemoveAll(suite.sqlStoreRootPath)
+}
+
+func TestSqlStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(SQLStoreTestSuite))
+}

--- a/store_test.go
+++ b/store_test.go
@@ -92,7 +92,7 @@ func (suite *MessageStoreTestSuite) TestMessageStore_SaveMessage_GetMessage() {
 		3: "and there was much rejoicing",
 	}
 	for seqNum, msg := range expectedMsgsBySeqNum {
-		suite.msgStore.SaveMessage(seqNum, []byte(msg))
+		require.Nil(t, suite.msgStore.SaveMessage(seqNum, []byte(msg)))
 	}
 
 	// When the messages are retrieved from the MessageStore
@@ -132,9 +132,9 @@ func (suite *MessageStoreTestSuite) TestMessageStore_GetMessages_VariousRanges()
 	t := suite.T()
 
 	// Given the following saved messages
-	suite.msgStore.SaveMessage(1, []byte("hello"))
-	suite.msgStore.SaveMessage(2, []byte("cruel"))
-	suite.msgStore.SaveMessage(3, []byte("world"))
+	require.Nil(t, suite.msgStore.SaveMessage(1, []byte("hello")))
+	require.Nil(t, suite.msgStore.SaveMessage(2, []byte("cruel")))
+	require.Nil(t, suite.msgStore.SaveMessage(3, []byte("world")))
 
 	// When the following requests are made to the store
 	var testCases = []struct {
@@ -163,7 +163,7 @@ func (suite *MessageStoreTestSuite) TestMessageStore_GetMessages_VariousRanges()
 	}
 }
 
-func (suite *MessageStoreTestSuite) TestMemoryStoreFactory_CreationTime() {
+func (suite *MessageStoreTestSuite) TestMessageStore_CreationTime() {
 	t0 := time.Now()
 	suite.msgStore.Reset()
 	t1 := time.Now()


### PR DESCRIPTION
- New session settings: `SQLDriver` and `SQLDataSourceName`
- Uses the `sql` pkg directly (no external deps)
- The DDL files in `_sql/` are borrowed from `quickfix/c++` and `quickfix/j`
- Only tested with `sqlite3` driver so far
- Should work with the `mysql` driver (will probably need `parseTime=true` in the DSN)
- It may be useful going forward to have separate mysql, sqlite, postgresql, etc. impls of `sqlStore` to work around the differences (e.g. `DATETIME` parsing and `?` vs `$1` in prepared statements)

Refs #88 

