### PR TITLE
Return better error when group delim not found

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -61,7 +61,7 @@ func handleAcceptorConnection(netConn net.Conn, qualifiedSessionIDs map[SessionI
 		return
 	}
 
-	msg, err := parseMessage(msgBytes)
+	msg, err := ParseMessage(msgBytes)
 	if err != nil {
 		log.OnEvent("Invalid message: " + string(msgBytes) + err.Error())
 		return

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,7 @@ const (
 	rejectReasonInvalidMsgType                            = 11
 	rejectReasonTagAppearsMoreThanOnce                    = 13
 	rejectReasonTagSpecifiedOutOfRequiredOrder            = 14
+	rejectReasonRepeatingGroupFieldsOutOfOrder            = 15
 	rejectReasonIncorrectNumInGroupCountForRepeatingGroup = 16
 )
 
@@ -58,6 +59,16 @@ func NewBusinessMessageRejectError(err string, rejectReason int, refTagID *Tag) 
 //incorrectDataFormatForValue returns an error indicating a field that cannot be parsed as the type required.
 func incorrectDataFormatForValue(tag Tag) MessageRejectError {
 	return NewMessageRejectError("Incorrect data format for value", rejectReasonIncorrectDataFormatForValue, &tag)
+}
+
+//repeatingGroupFieldsOutOfOrder returns an error indicating a problem parsing repeating groups fields
+func repeatingGroupFieldsOutOfOrder(tag Tag, reason string) MessageRejectError {
+	if reason != "" {
+		reason = fmt.Sprintf("Repeating group fields out of order (%s)", reason)
+	} else {
+		reason = "Repeating group fields out of order"
+	}
+	return NewMessageRejectError(reason, rejectReasonRepeatingGroupFieldsOutOfOrder, &tag)
 }
 
 //ValueIsIncorrect returns an error indicating a field with value that is not valid.

--- a/field_map.go
+++ b/field_map.go
@@ -128,6 +128,9 @@ func (m FieldMap) GetGroup(parser *RepeatingGroup) MessageRejectError {
 	}
 
 	if _, err := parser.read(tagValues); err != nil {
+		if msgRejErr, ok := err.(MessageRejectError); ok {
+			return msgRejErr
+		}
 		return incorrectDataFormatForValue(parser.Tag)
 	}
 

--- a/in_session.go
+++ b/in_session.go
@@ -145,7 +145,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 	seqNum := beginSeqNo
 	nextSeqNum := seqNum
 	for _, msgBytes := range msgs {
-		msg, _ := parseMessage(msgBytes)
+		msg, _ := ParseMessage(msgBytes)
 		msgType, _ := msg.Header.GetString(tagMsgType)
 		sentMessageSeqNum, _ := msg.Header.GetInt(tagMsgSeqNum)
 

--- a/message.go
+++ b/message.go
@@ -51,11 +51,6 @@ func (m *Message) Init() {
 
 //ParseMessage constructs a Message from a byte slice wrapping a FIX message.
 func ParseMessage(rawMessage []byte) (Message, error) {
-	return parseMessage(rawMessage)
-}
-
-//parseMessage constructs a Message from a byte slice wrapping a FIX message.
-func parseMessage(rawMessage []byte) (Message, error) {
 	msg := NewMessage()
 	msg.rawMessage = rawMessage
 

--- a/message.go
+++ b/message.go
@@ -3,8 +3,9 @@ package quickfix
 import (
 	"bytes"
 	"fmt"
-	"github.com/quickfixgo/quickfix/enum"
 	"time"
+
+	"github.com/quickfixgo/quickfix/enum"
 )
 
 //Message is a FIX Message abstraction.
@@ -46,6 +47,11 @@ func (m *Message) Init() {
 	m.Header.init(headerFieldOrder)
 	m.Body.init(normalFieldOrder)
 	m.Trailer.init(trailerFieldOrder)
+}
+
+//ParseMessage constructs a Message from a byte slice wrapping a FIX message.
+func ParseMessage(rawMessage []byte) (Message, error) {
+	return parseMessage(rawMessage)
 }
 
 //parseMessage constructs a Message from a byte slice wrapping a FIX message.

--- a/message_test.go
+++ b/message_test.go
@@ -13,16 +13,16 @@ func BenchmarkParseMessage(b *testing.B) {
 
 	var msg Message
 	for i := 0; i < b.N; i++ {
-		msg, _ = parseMessage(rawMsg)
+		msg, _ = ParseMessage(rawMsg)
 	}
 
 	msgResult = msg
 }
 
-func TestMessage_parseMessage(t *testing.T) {
+func TestMessage_ParseMessage(t *testing.T) {
 	rawMsg := []byte("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 
-	msg, err := parseMessage(rawMsg)
+	msg, err := ParseMessage(rawMsg)
 
 	if err != nil {
 		t.Error("Unexpected error, ", err)
@@ -47,7 +47,7 @@ func TestMessage_parseMessage(t *testing.T) {
 func TestMessage_parseOutOfOrder(t *testing.T) {
 	//allow fields out of order, save for validation
 	rawMsg := []byte("8=FIX.4.09=8135=D11=id21=338=10040=154=155=MSFT34=249=TW52=20140521-22:07:0956=ISLD10=250")
-	_, err := parseMessage(rawMsg)
+	_, err := ParseMessage(rawMsg)
 
 	if err != nil {
 		t.Error("Should not have gotten error, got ", err)
@@ -78,7 +78,7 @@ func TestMessage_Build(t *testing.T) {
 func TestMessage_ReBuild(t *testing.T) {
 	rawMsg := []byte("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 
-	msg, _ := parseMessage(rawMsg)
+	msg, _ := ParseMessage(rawMsg)
 
 	msg.Header.SetField(tagOrigSendingTime, FIXString("20140515-19:49:56.659"))
 	msg.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
@@ -99,7 +99,7 @@ func TestMessage_ReBuild(t *testing.T) {
 }
 
 func TestMessage_reverseRoute(t *testing.T) {
-	msg, _ := parseMessage([]byte("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
+	msg, _ := ParseMessage([]byte("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
 
 	builder := msg.reverseRoute()
 
@@ -135,7 +135,7 @@ func TestMessage_reverseRoute(t *testing.T) {
 }
 
 func TestMessage_reverseRouteIgnoreEmpty(t *testing.T) {
-	msg, _ := parseMessage([]byte("8=FIX.4.09=12835=D34=249=TW52=20060102-15:04:0556=ISLD115=116=CS128=MG129=CB11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
+	msg, _ := ParseMessage([]byte("8=FIX.4.09=12835=D34=249=TW52=20060102-15:04:0556=ISLD115=116=CS128=MG129=CB11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
 	builder := msg.reverseRoute()
 
 	if builder.Header.Has(tagDeliverToCompID) {
@@ -146,7 +146,7 @@ func TestMessage_reverseRouteIgnoreEmpty(t *testing.T) {
 func TestMessage_reverseRouteFIX40(t *testing.T) {
 	//onbehalfof/deliverto location id not supported in fix 4.0
 
-	msg, _ := parseMessage([]byte("8=FIX.4.09=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
+	msg, _ := ParseMessage([]byte("8=FIX.4.09=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
 
 	builder := msg.reverseRoute()
 

--- a/repeating_group.go
+++ b/repeating_group.go
@@ -112,8 +112,12 @@ func (f RepeatingGroup) groupTagOrder() tagOrder {
 	}
 }
 
+func (f RepeatingGroup) delimiter() Tag {
+	return f.GroupTemplate[0].Tag()
+}
+
 func (f RepeatingGroup) isDelimiter(t Tag) bool {
-	return t == f.GroupTemplate[0].Tag()
+	return t == f.delimiter()
 }
 
 func (f *RepeatingGroup) read(tv tagValues) (tagValues, error) {
@@ -152,7 +156,7 @@ func (f *RepeatingGroup) read(tv tagValues) (tagValues, error) {
 	}
 
 	if len(f.Groups) != expectedGroupSize {
-		return tv, fmt.Errorf("Only found %v instead of %v expected groups, is template wrong?", len(f.Groups), expectedGroupSize)
+		return tv, repeatingGroupFieldsOutOfOrder(f.Tag, fmt.Sprintf("group %v: template is wrong or delimiter %v not found: expected %v groups, but found %v", f.Tag, f.delimiter(), expectedGroupSize, len(f.Groups)))
 	}
 
 	return tv, err

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -195,7 +195,7 @@ func TestRepeatingGroup_ReadComplete(t *testing.T) {
 
 	rawMsg := []byte("8=FIXT.1.19=26835=W34=711849=TEST52=20151027-18:41:52.69856=TST22=9948=TSTX15262=7268=4269=4270=0.07499272=20151027273=18:41:52.698269=7270=0.07501272=20151027273=18:41:52.698269=8270=0.07494272=20151027273=18:41:52.698269=B271=60272=20151027273=18:41:52.69810=163")
 
-	msg, err := parseMessage(rawMsg)
+	msg, err := ParseMessage(rawMsg)
 
 	if err != nil {
 		t.Error("Unexpected error, ", err)

--- a/session.go
+++ b/session.go
@@ -543,7 +543,7 @@ func (s *session) run(msgIn chan fixIn, msgOut chan []byte, quit chan bool) {
 		case fixIn, ok := <-msgIn:
 			if ok {
 				s.log.OnIncoming(string(fixIn.bytes))
-				if msg, err := parseMessage(fixIn.bytes); err != nil {
+				if msg, err := ParseMessage(fixIn.bytes); err != nil {
 					s.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), fixIn.bytes)
 				} else {
 					msg.ReceiveTime = fixIn.receiveTime

--- a/session_test.go
+++ b/session_test.go
@@ -54,7 +54,7 @@ func TestSession_CheckCorrectCompID(t *testing.T) {
 		}
 
 		msgBytes, _ := builder.Build()
-		msg, _ := parseMessage(msgBytes)
+		msg, _ := ParseMessage(msgBytes)
 		err := session.checkCompID(msg)
 
 		if err == nil {
@@ -85,7 +85,7 @@ func TestSession_CheckBeginString(t *testing.T) {
 	//wrong value
 	builder.Header.SetField(tagBeginString, FIXString("FIX.4.4"))
 	msgBytes, _ := builder.Build()
-	msg, _ := parseMessage(msgBytes)
+	msg, _ := ParseMessage(msgBytes)
 
 	err := session.checkBeginString(msg)
 	if err == nil {
@@ -95,7 +95,7 @@ func TestSession_CheckBeginString(t *testing.T) {
 
 	builder.Header.SetField(tagBeginString, FIXString(session.sessionID.BeginString))
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkBeginString(msg)
 
@@ -109,7 +109,7 @@ func TestSession_CheckTargetTooHigh(t *testing.T) {
 	session := session{store: store}
 	builder := buildMessage()
 	msgBytes, _ := builder.Build()
-	msg, _ := parseMessage(msgBytes)
+	msg, _ := ParseMessage(msgBytes)
 
 	store.SetNextTargetMsgSeqNum(45)
 
@@ -127,7 +127,7 @@ func TestSession_CheckTargetTooHigh(t *testing.T) {
 	//too low
 	builder.Header.SetField(tagMsgSeqNum, FIXInt(47))
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 	err = session.checkTargetTooHigh(msg)
 
 	if err == nil {
@@ -138,7 +138,7 @@ func TestSession_CheckTargetTooHigh(t *testing.T) {
 	//spot on
 	builder.Header.SetField(tagMsgSeqNum, FIXInt(45))
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkTargetTooHigh(msg)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 	session := session{}
 	builder := buildMessage()
 	msgBytes, _ := builder.Build()
-	msg, _ := parseMessage(msgBytes)
+	msg, _ := ParseMessage(msgBytes)
 
 	//missing sending time
 	err := session.checkSendingTime(msg)
@@ -165,7 +165,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 	sendingTime := time.Now().Add(time.Duration(-200) * time.Second)
 	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkSendingTime(msg)
 	if err == nil {
@@ -179,7 +179,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 	sendingTime = time.Now().Add(time.Duration(200) * time.Second)
 	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkSendingTime(msg)
 	if err == nil {
@@ -193,7 +193,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 	sendingTime = time.Now()
 	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkSendingTime(msg)
 	if err != nil {
@@ -207,7 +207,7 @@ func TestSession_CheckTargetTooLow(t *testing.T) {
 
 	builder := buildMessage()
 	msgBytes, _ := builder.Build()
-	msg, _ := parseMessage(msgBytes)
+	msg, _ := ParseMessage(msgBytes)
 
 	store.SetNextTargetMsgSeqNum(45)
 
@@ -224,7 +224,7 @@ func TestSession_CheckTargetTooLow(t *testing.T) {
 	//too low
 	builder.Header.SetField(tagMsgSeqNum, FIXInt(43))
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkTargetTooLow(msg)
 	if err == nil {
@@ -235,7 +235,7 @@ func TestSession_CheckTargetTooLow(t *testing.T) {
 	//spot on
 	builder.Header.SetField(tagMsgSeqNum, FIXInt(45))
 	msgBytes, _ = builder.Build()
-	msg, _ = parseMessage(msgBytes)
+	msg, _ = ParseMessage(msgBytes)
 
 	err = session.checkTargetTooLow(msg)
 	if err != nil {

--- a/validation_test.go
+++ b/validation_test.go
@@ -35,7 +35,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		msg, _ := parseMessage(test.MessageBytes)
+		msg, _ := ParseMessage(test.MessageBytes)
 		reject := validate(test.DataDictionary, msg)
 
 		switch {


### PR DESCRIPTION
Now returns "Repeating group fields out of order" (rej reason 15) when delim field not found.
Needed `ParseMessage` for the unit test, so addresses #110 and #77 as well.

Fixes #103 
Fixes #110
Fixes #77