### PR TITLE
Make gen import path relative

### DIFF
--- a/gen/generate-fields/main.go
+++ b/gen/generate-fields/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/quickfixgo/quickfix/gen"
 	"github.com/quickfixgo/quickfix/datadictionary"
+	"github.com/quickfixgo/quickfix/gen"
 )
 
 var (
@@ -92,6 +92,8 @@ func genFields() {
 			fallthrough
 		case "UTCTIMEONLY":
 			fallthrough
+		case "UTCDATE":
+			fallthrough
 		case "UTCDATEONLY":
 			fallthrough
 		case "TZTIMEONLY":
@@ -122,6 +124,8 @@ func genFields() {
 			baseType = "FIXUTCTimestamp"
 
 		case "QTY":
+			fallthrough
+		case "QUANTITY":
 			fallthrough
 		case "AMT":
 			fallthrough

--- a/gen/generate-fields/main.go
+++ b/gen/generate-fields/main.go
@@ -55,7 +55,7 @@ func genFields() {
 	fileOut := "package field\n"
 	fileOut += "import(\n"
 	fileOut += "\"github.com/quickfixgo/quickfix\"\n"
-	fileOut += "\"github.com/quickfixgo/quickfix/tag\"\n"
+	fileOut += "\"" + gen.GetImportPathRoot() + "/tag\"\n"
 	fileOut += ")\n"
 
 	for _, tag := range sortedTags {


### PR DESCRIPTION
- Do not hardcode the root import path.
- Generated code files should have import statements that import the other locally generated code, not `"github.com/quickfixgo/quickfix"`.
- Add missing types (e.g. `UTCDATE`) to generators, which were causing `FIX42.xml` field generation to fail if run by itself.
Note: For now, users will have to copy `enum/begin_string.go` to their local `enum` directory.  Correct solution there TBD...