### PR TITLE
validator interface

### DIFF
--- a/session_id.go
+++ b/session_id.go
@@ -10,6 +10,7 @@ type SessionID struct {
 	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier string
 }
 
+//IsFIXT returns true if the SessionID has a FIXT BeginString
 func (s SessionID) IsFIXT() bool {
 	return s.BeginString == enum.BeginStringFIXT11
 }

--- a/session_id.go
+++ b/session_id.go
@@ -2,11 +2,16 @@ package quickfix
 
 import (
 	"fmt"
+	"github.com/quickfixgo/quickfix/enum"
 )
 
 // SessionID is a unique identifer of a Session
 type SessionID struct {
 	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier string
+}
+
+func (s SessionID) IsFIXT() bool {
+	return s.BeginString == enum.BeginStringFIXT11
 }
 
 func (s SessionID) String() string {


### PR DESCRIPTION
Related to #107

The changes here propose a small refactor for message validation. I've created a `validator` interface, with two implementations, one for FIX, and another for FIXT. We currently have some logic in the `session` struct surrounding validation that determines which data dictionaries to use. With these changes, I've been able to move all of that decision making into the `validation` file.

Additionally, this refactor will encourage a more scalable approach for upcoming validation configuration enhancements, ex. #107

Thoughts 💭  and concerns 😰  are more than welcome. Please and thank you! 😊 