### PR TITLE
fixes required group validation error

### DIFF
--- a/datadictionary/datadictionary.go
+++ b/datadictionary/datadictionary.go
@@ -288,9 +288,6 @@ func NewMessageDef(name, msgType string, parts []MessagePart) *MessageDef {
 
 		if allowRequired && field.Required() {
 			msg.RequiredTags.Add(field.Tag())
-			for _, t := range field.requiredChildTags() {
-				msg.RequiredTags.Add(t)
-			}
 		}
 	}
 

--- a/datadictionary/message_def_test.go
+++ b/datadictionary/message_def_test.go
@@ -59,7 +59,7 @@ func TestNewMessageDef(t *testing.T) {
 		{
 			parts:                 []datadictionary.MessagePart{requiredGroup1},
 			expectedTags:          datadictionary.TagSet{11: struct{}{}, 12: struct{}{}, 13: struct{}{}},
-			expectedRequiredTags:  datadictionary.TagSet{11: struct{}{}, 13: struct{}{}},
+			expectedRequiredTags:  datadictionary.TagSet{13: struct{}{}},
 			expectedRequiredParts: []datadictionary.MessagePart{requiredGroup1},
 		},
 		{


### PR DESCRIPTION
Fixes a validation bug where a message is rejected when it includes a required group of size 0.  The validation will reject the message with a required tag missing if the group is defined to have required fields within it.  If the group is of size 0, those required field groups should not be included in the message.