### PR TITLE
RefTagID is not known to BusinessMessageReject type

### DIFF
--- a/session.go
+++ b/session.go
@@ -468,16 +468,16 @@ func (s *session) doReject(msg Message, rej MessageRejectError) {
 			case rej.RejectReason() > rejectReasonInvalidMsgType && s.sessionID.BeginString == enum.BeginStringFIX42:
 				//fix42 knows up to invalid msg type
 			}
+
+			if refTagID := rej.RefTagID(); refTagID != nil {
+				reply.Body.SetField(tagRefTagID, FIXInt(*refTagID))
+			}
 		}
 		reply.Body.SetField(tagText, FIXString(rej.Error()))
 
 		var msgType FIXString
 		if err := msg.Header.GetField(tagMsgType, &msgType); err == nil {
 			reply.Body.SetField(tagRefMsgType, msgType)
-		}
-
-		if refTagID := rej.RefTagID(); refTagID != nil {
-			reply.Body.SetField(tagRefTagID, FIXInt(*refTagID))
 		}
 	} else {
 		reply.Header.SetField(tagMsgType, FIXString("3"))


### PR DESCRIPTION
RefTagID does not appear on BusinessMessageReject type, and should not have it set.

I don't see coverage of `in_session.go` which uses `doReject`. Open approaches on that.