### PR TITLE
Expose sql.DB's SetConnMaxLifetime() in settings

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -18,5 +18,6 @@ const (
 	FileStorePath            string = "FileStorePath"
 	SQLDriver                string = "SQLDriver"
 	SQLDataSourceName        string = "SQLDataSourceName"
+	SQLConnMaxLifetime       string = "SQLConnMaxLifetime"
 	ValidateFieldsOutOfOrder string = "ValidateFieldsOutOfOrder"
 )

--- a/config/doc.go
+++ b/config/doc.go
@@ -138,5 +138,15 @@ The name of the database driver to use (see https://github.com/golang/go/wiki/SQ
 SQLDataSourceName
 
 The driver-specific data source name of the database to use.  Only used with SqlStoreFactory.
+
+SQLConnMaxLifetime
+
+SetConnMaxLifetime sets the maximum duration of time that a database connection may be reused (see https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime).  Defaults to zero, which causes connections to be reused forever.  Only used with SqlStoreFactory.
+
+If your database server has a config option to close inactive connections after some duration (e.g. MySQL "wait_timeout"), set SQLConnMaxLifetime to a value less than that duration.
+
+Example Values:
+ SQLConnMaxLifetime=14400s # 14400 seconds
+ SQLConnMaxLifetime=2h45m  # 2 hours and 45 minutes
 */
 package config

--- a/session_settings.go
+++ b/session_settings.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 )
 
 //SessionSettings maps session settings to values with typed accessors.
@@ -59,6 +60,17 @@ func (s *SessionSettings) IntSetting(setting string) (int, error) {
 	}
 
 	return strconv.Atoi(stringVal)
+}
+
+//DurationSetting returns the requested setting parsed as a time.Duration.  Returns an error if the setting is not set or cannot be parsed as a time.Duration.
+func (s *SessionSettings) DurationSetting(setting string) (val time.Duration, err error) {
+	stringVal, err := s.Setting(setting)
+
+	if err != nil {
+		return
+	}
+
+	return time.ParseDuration(stringVal)
 }
 
 //BoolSetting returns the requested setting parsed as a boolean.  Returns an errror if the setting is not set or cannot be parsed as a bool.

--- a/sqlstore_test.go
+++ b/sqlstore_test.go
@@ -47,6 +47,7 @@ func (suite *SQLStoreTestSuite) SetupTest() {
 [DEFAULT]
 SQLDriver=%s
 SQLDataSourceName=%s
+SQLConnMaxLifetime=14400s
 
 [SESSION]
 BeginString=%s


### PR DESCRIPTION
When using a database server that closes inactive connections after some
duration, set `SQLConnMaxLifetime` to a value less than that duration.
Otherwise, the connection will be reused forever, and this could result in a
dropped connection.

For example, if you are using MySQL configured with `wait_timeout = 28800`, use
something like `SQLConnMaxLifetime=14400s`.

Refs #139