### PR TITLE
Misc field type refactoring

### DIFF
--- a/field/fields.go
+++ b/field/fields.go
@@ -2006,12 +2006,12 @@ func (f ComplexEventEndDateField) Tag() quickfix.Tag { return tag.ComplexEventEn
 
 //NewComplexEventEndDate returns a new ComplexEventEndDateField initialized with val
 func NewComplexEventEndDate(val time.Time) ComplexEventEndDateField {
-	return ComplexEventEndDateField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ComplexEventEndDateField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewComplexEventEndDateNoMillis returns a new ComplexEventEndDateField initialized with val without millisecs
 func NewComplexEventEndDateNoMillis(val time.Time) ComplexEventEndDateField {
-	return ComplexEventEndDateField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ComplexEventEndDateField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //ComplexEventEndTimeField is a UTCTIMEONLY field
@@ -2081,12 +2081,12 @@ func (f ComplexEventStartDateField) Tag() quickfix.Tag { return tag.ComplexEvent
 
 //NewComplexEventStartDate returns a new ComplexEventStartDateField initialized with val
 func NewComplexEventStartDate(val time.Time) ComplexEventStartDateField {
-	return ComplexEventStartDateField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ComplexEventStartDateField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewComplexEventStartDateNoMillis returns a new ComplexEventStartDateField initialized with val without millisecs
 func NewComplexEventStartDateNoMillis(val time.Time) ComplexEventStartDateField {
-	return ComplexEventStartDateField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ComplexEventStartDateField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //ComplexEventStartTimeField is a UTCTIMEONLY field
@@ -2372,12 +2372,12 @@ func (f ContraTradeTimeField) Tag() quickfix.Tag { return tag.ContraTradeTime }
 
 //NewContraTradeTime returns a new ContraTradeTimeField initialized with val
 func NewContraTradeTime(val time.Time) ContraTradeTimeField {
-	return ContraTradeTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ContraTradeTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewContraTradeTimeNoMillis returns a new ContraTradeTimeField initialized with val without millisecs
 func NewContraTradeTimeNoMillis(val time.Time) ContraTradeTimeField {
-	return ContraTradeTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ContraTradeTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //ContraTraderField is a STRING field
@@ -3100,12 +3100,12 @@ func (f DerivativeEventTimeField) Tag() quickfix.Tag { return tag.DerivativeEven
 
 //NewDerivativeEventTime returns a new DerivativeEventTimeField initialized with val
 func NewDerivativeEventTime(val time.Time) DerivativeEventTimeField {
-	return DerivativeEventTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return DerivativeEventTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewDerivativeEventTimeNoMillis returns a new DerivativeEventTimeField initialized with val without millisecs
 func NewDerivativeEventTimeNoMillis(val time.Time) DerivativeEventTimeField {
-	return DerivativeEventTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return DerivativeEventTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //DerivativeEventTypeField is a INT field
@@ -4106,12 +4106,12 @@ func (f EffectiveTimeField) Tag() quickfix.Tag { return tag.EffectiveTime }
 
 //NewEffectiveTime returns a new EffectiveTimeField initialized with val
 func NewEffectiveTime(val time.Time) EffectiveTimeField {
-	return EffectiveTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return EffectiveTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewEffectiveTimeNoMillis returns a new EffectiveTimeField initialized with val without millisecs
 func NewEffectiveTimeNoMillis(val time.Time) EffectiveTimeField {
-	return EffectiveTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return EffectiveTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //EmailThreadIDField is a STRING field
@@ -4654,12 +4654,12 @@ func (f EventTimeField) Tag() quickfix.Tag { return tag.EventTime }
 
 //NewEventTime returns a new EventTimeField initialized with val
 func NewEventTime(val time.Time) EventTimeField {
-	return EventTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return EventTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewEventTimeNoMillis returns a new EventTimeField initialized with val without millisecs
 func NewEventTimeNoMillis(val time.Time) EventTimeField {
-	return EventTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return EventTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //EventTypeField is a INT field
@@ -4868,12 +4868,12 @@ func (f ExecValuationPointField) Tag() quickfix.Tag { return tag.ExecValuationPo
 
 //NewExecValuationPoint returns a new ExecValuationPointField initialized with val
 func NewExecValuationPoint(val time.Time) ExecValuationPointField {
-	return ExecValuationPointField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ExecValuationPointField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewExecValuationPointNoMillis returns a new ExecValuationPointField initialized with val without millisecs
 func NewExecValuationPointNoMillis(val time.Time) ExecValuationPointField {
-	return ExecValuationPointField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ExecValuationPointField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //ExerciseMethodField is a CHAR field
@@ -4961,12 +4961,12 @@ func (f ExpireTimeField) Tag() quickfix.Tag { return tag.ExpireTime }
 
 //NewExpireTime returns a new ExpireTimeField initialized with val
 func NewExpireTime(val time.Time) ExpireTimeField {
-	return ExpireTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ExpireTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewExpireTimeNoMillis returns a new ExpireTimeField initialized with val without millisecs
 func NewExpireTimeNoMillis(val time.Time) ExpireTimeField {
-	return ExpireTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ExpireTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //FactorField is a FLOAT field
@@ -5320,12 +5320,12 @@ func (f HopSendingTimeField) Tag() quickfix.Tag { return tag.HopSendingTime }
 
 //NewHopSendingTime returns a new HopSendingTimeField initialized with val
 func NewHopSendingTime(val time.Time) HopSendingTimeField {
-	return HopSendingTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return HopSendingTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewHopSendingTimeNoMillis returns a new HopSendingTimeField initialized with val without millisecs
 func NewHopSendingTimeNoMillis(val time.Time) HopSendingTimeField {
-	return HopSendingTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return HopSendingTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //HostCrossIDField is a STRING field
@@ -5875,12 +5875,12 @@ func (f LastUpdateTimeField) Tag() quickfix.Tag { return tag.LastUpdateTime }
 
 //NewLastUpdateTime returns a new LastUpdateTimeField initialized with val
 func NewLastUpdateTime(val time.Time) LastUpdateTimeField {
-	return LastUpdateTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return LastUpdateTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewLastUpdateTimeNoMillis returns a new LastUpdateTimeField initialized with val without millisecs
 func NewLastUpdateTimeNoMillis(val time.Time) LastUpdateTimeField {
-	return LastUpdateTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return LastUpdateTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //LateIndicatorField is a BOOLEAN field
@@ -10296,12 +10296,12 @@ func (f OnBehalfOfSendingTimeField) Tag() quickfix.Tag { return tag.OnBehalfOfSe
 
 //NewOnBehalfOfSendingTime returns a new OnBehalfOfSendingTimeField initialized with val
 func NewOnBehalfOfSendingTime(val time.Time) OnBehalfOfSendingTimeField {
-	return OnBehalfOfSendingTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return OnBehalfOfSendingTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewOnBehalfOfSendingTimeNoMillis returns a new OnBehalfOfSendingTimeField initialized with val without millisecs
 func NewOnBehalfOfSendingTimeNoMillis(val time.Time) OnBehalfOfSendingTimeField {
-	return OnBehalfOfSendingTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return OnBehalfOfSendingTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //OnBehalfOfSubIDField is a STRING field
@@ -10642,12 +10642,12 @@ func (f OrigOrdModTimeField) Tag() quickfix.Tag { return tag.OrigOrdModTime }
 
 //NewOrigOrdModTime returns a new OrigOrdModTimeField initialized with val
 func NewOrigOrdModTime(val time.Time) OrigOrdModTimeField {
-	return OrigOrdModTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return OrigOrdModTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewOrigOrdModTimeNoMillis returns a new OrigOrdModTimeField initialized with val without millisecs
 func NewOrigOrdModTimeNoMillis(val time.Time) OrigOrdModTimeField {
-	return OrigOrdModTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return OrigOrdModTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //OrigPosReqRefIDField is a STRING field
@@ -10680,12 +10680,12 @@ func (f OrigSendingTimeField) Tag() quickfix.Tag { return tag.OrigSendingTime }
 
 //NewOrigSendingTime returns a new OrigSendingTimeField initialized with val
 func NewOrigSendingTime(val time.Time) OrigSendingTimeField {
-	return OrigSendingTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return OrigSendingTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewOrigSendingTimeNoMillis returns a new OrigSendingTimeField initialized with val without millisecs
 func NewOrigSendingTimeNoMillis(val time.Time) OrigSendingTimeField {
-	return OrigSendingTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return OrigSendingTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //OrigTimeField is a UTCTIMESTAMP field
@@ -10696,12 +10696,12 @@ func (f OrigTimeField) Tag() quickfix.Tag { return tag.OrigTime }
 
 //NewOrigTime returns a new OrigTimeField initialized with val
 func NewOrigTime(val time.Time) OrigTimeField {
-	return OrigTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return OrigTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewOrigTimeNoMillis returns a new OrigTimeField initialized with val without millisecs
 func NewOrigTimeNoMillis(val time.Time) OrigTimeField {
-	return OrigTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return OrigTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //OrigTradeDateField is a LOCALMKTDATE field
@@ -11935,12 +11935,12 @@ func (f QuoteSetValidUntilTimeField) Tag() quickfix.Tag { return tag.QuoteSetVal
 
 //NewQuoteSetValidUntilTime returns a new QuoteSetValidUntilTimeField initialized with val
 func NewQuoteSetValidUntilTime(val time.Time) QuoteSetValidUntilTimeField {
-	return QuoteSetValidUntilTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return QuoteSetValidUntilTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewQuoteSetValidUntilTimeNoMillis returns a new QuoteSetValidUntilTimeField initialized with val without millisecs
 func NewQuoteSetValidUntilTimeNoMillis(val time.Time) QuoteSetValidUntilTimeField {
-	return QuoteSetValidUntilTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return QuoteSetValidUntilTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //QuoteStatusField is a INT field
@@ -12391,12 +12391,12 @@ func (f RelSymTransactTimeField) Tag() quickfix.Tag { return tag.RelSymTransactT
 
 //NewRelSymTransactTime returns a new RelSymTransactTimeField initialized with val
 func NewRelSymTransactTime(val time.Time) RelSymTransactTimeField {
-	return RelSymTransactTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return RelSymTransactTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewRelSymTransactTimeNoMillis returns a new RelSymTransactTimeField initialized with val without millisecs
 func NewRelSymTransactTimeNoMillis(val time.Time) RelSymTransactTimeField {
-	return RelSymTransactTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return RelSymTransactTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //RelatdSymField is a STRING field
@@ -14288,12 +14288,12 @@ func (f SendingTimeField) Tag() quickfix.Tag { return tag.SendingTime }
 
 //NewSendingTime returns a new SendingTimeField initialized with val
 func NewSendingTime(val time.Time) SendingTimeField {
-	return SendingTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return SendingTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewSendingTimeNoMillis returns a new SendingTimeField initialized with val without millisecs
 func NewSendingTimeNoMillis(val time.Time) SendingTimeField {
-	return SendingTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return SendingTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //SeniorityField is a STRING field
@@ -14964,12 +14964,12 @@ func (f SideTimeInForceField) Tag() quickfix.Tag { return tag.SideTimeInForce }
 
 //NewSideTimeInForce returns a new SideTimeInForceField initialized with val
 func NewSideTimeInForce(val time.Time) SideTimeInForceField {
-	return SideTimeInForceField{quickfix.FIXUTCTimestamp{Value: val}}
+	return SideTimeInForceField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewSideTimeInForceNoMillis returns a new SideTimeInForceField initialized with val without millisecs
 func NewSideTimeInForceNoMillis(val time.Time) SideTimeInForceField {
-	return SideTimeInForceField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return SideTimeInForceField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //SideTradeReportIDField is a STRING field
@@ -14991,12 +14991,12 @@ func (f SideTrdRegTimestampField) Tag() quickfix.Tag { return tag.SideTrdRegTime
 
 //NewSideTrdRegTimestamp returns a new SideTrdRegTimestampField initialized with val
 func NewSideTrdRegTimestamp(val time.Time) SideTrdRegTimestampField {
-	return SideTrdRegTimestampField{quickfix.FIXUTCTimestamp{Value: val}}
+	return SideTrdRegTimestampField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewSideTrdRegTimestampNoMillis returns a new SideTrdRegTimestampField initialized with val without millisecs
 func NewSideTrdRegTimestampNoMillis(val time.Time) SideTrdRegTimestampField {
-	return SideTrdRegTimestampField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return SideTrdRegTimestampField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //SideTrdRegTimestampSrcField is a STRING field
@@ -15493,12 +15493,12 @@ func (f StrikeTimeField) Tag() quickfix.Tag { return tag.StrikeTime }
 
 //NewStrikeTime returns a new StrikeTimeField initialized with val
 func NewStrikeTime(val time.Time) StrikeTimeField {
-	return StrikeTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return StrikeTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewStrikeTimeNoMillis returns a new StrikeTimeField initialized with val without millisecs
 func NewStrikeTimeNoMillis(val time.Time) StrikeTimeField {
-	return StrikeTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return StrikeTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //StrikeValueField is a FLOAT field
@@ -16114,12 +16114,12 @@ func (f TradSesCloseTimeField) Tag() quickfix.Tag { return tag.TradSesCloseTime 
 
 //NewTradSesCloseTime returns a new TradSesCloseTimeField initialized with val
 func NewTradSesCloseTime(val time.Time) TradSesCloseTimeField {
-	return TradSesCloseTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TradSesCloseTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTradSesCloseTimeNoMillis returns a new TradSesCloseTimeField initialized with val without millisecs
 func NewTradSesCloseTimeNoMillis(val time.Time) TradSesCloseTimeField {
-	return TradSesCloseTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TradSesCloseTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TradSesEndTimeField is a UTCTIMESTAMP field
@@ -16130,12 +16130,12 @@ func (f TradSesEndTimeField) Tag() quickfix.Tag { return tag.TradSesEndTime }
 
 //NewTradSesEndTime returns a new TradSesEndTimeField initialized with val
 func NewTradSesEndTime(val time.Time) TradSesEndTimeField {
-	return TradSesEndTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TradSesEndTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTradSesEndTimeNoMillis returns a new TradSesEndTimeField initialized with val without millisecs
 func NewTradSesEndTimeNoMillis(val time.Time) TradSesEndTimeField {
-	return TradSesEndTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TradSesEndTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TradSesEventField is a INT field
@@ -16179,12 +16179,12 @@ func (f TradSesOpenTimeField) Tag() quickfix.Tag { return tag.TradSesOpenTime }
 
 //NewTradSesOpenTime returns a new TradSesOpenTimeField initialized with val
 func NewTradSesOpenTime(val time.Time) TradSesOpenTimeField {
-	return TradSesOpenTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TradSesOpenTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTradSesOpenTimeNoMillis returns a new TradSesOpenTimeField initialized with val without millisecs
 func NewTradSesOpenTimeNoMillis(val time.Time) TradSesOpenTimeField {
-	return TradSesOpenTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TradSesOpenTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TradSesPreCloseTimeField is a UTCTIMESTAMP field
@@ -16195,12 +16195,12 @@ func (f TradSesPreCloseTimeField) Tag() quickfix.Tag { return tag.TradSesPreClos
 
 //NewTradSesPreCloseTime returns a new TradSesPreCloseTimeField initialized with val
 func NewTradSesPreCloseTime(val time.Time) TradSesPreCloseTimeField {
-	return TradSesPreCloseTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TradSesPreCloseTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTradSesPreCloseTimeNoMillis returns a new TradSesPreCloseTimeField initialized with val without millisecs
 func NewTradSesPreCloseTimeNoMillis(val time.Time) TradSesPreCloseTimeField {
-	return TradSesPreCloseTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TradSesPreCloseTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TradSesReqIDField is a STRING field
@@ -16222,12 +16222,12 @@ func (f TradSesStartTimeField) Tag() quickfix.Tag { return tag.TradSesStartTime 
 
 //NewTradSesStartTime returns a new TradSesStartTimeField initialized with val
 func NewTradSesStartTime(val time.Time) TradSesStartTimeField {
-	return TradSesStartTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TradSesStartTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTradSesStartTimeNoMillis returns a new TradSesStartTimeField initialized with val without millisecs
 func NewTradSesStartTimeNoMillis(val time.Time) TradSesStartTimeField {
-	return TradSesStartTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TradSesStartTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TradSesStatusField is a INT field
@@ -16579,12 +16579,12 @@ func (f TransBkdTimeField) Tag() quickfix.Tag { return tag.TransBkdTime }
 
 //NewTransBkdTime returns a new TransBkdTimeField initialized with val
 func NewTransBkdTime(val time.Time) TransBkdTimeField {
-	return TransBkdTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TransBkdTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTransBkdTimeNoMillis returns a new TransBkdTimeField initialized with val without millisecs
 func NewTransBkdTimeNoMillis(val time.Time) TransBkdTimeField {
-	return TransBkdTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TransBkdTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TransactTimeField is a UTCTIMESTAMP field
@@ -16595,12 +16595,12 @@ func (f TransactTimeField) Tag() quickfix.Tag { return tag.TransactTime }
 
 //NewTransactTime returns a new TransactTimeField initialized with val
 func NewTransactTime(val time.Time) TransactTimeField {
-	return TransactTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TransactTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTransactTimeNoMillis returns a new TransactTimeField initialized with val without millisecs
 func NewTransactTimeNoMillis(val time.Time) TransactTimeField {
-	return TransactTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TransactTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TransferReasonField is a STRING field
@@ -16633,12 +16633,12 @@ func (f TrdRegTimestampField) Tag() quickfix.Tag { return tag.TrdRegTimestamp }
 
 //NewTrdRegTimestamp returns a new TrdRegTimestampField initialized with val
 func NewTrdRegTimestamp(val time.Time) TrdRegTimestampField {
-	return TrdRegTimestampField{quickfix.FIXUTCTimestamp{Value: val}}
+	return TrdRegTimestampField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewTrdRegTimestampNoMillis returns a new TrdRegTimestampField initialized with val without millisecs
 func NewTrdRegTimestampNoMillis(val time.Time) TrdRegTimestampField {
-	return TrdRegTimestampField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return TrdRegTimestampField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //TrdRegTimestampOriginField is a STRING field
@@ -18247,12 +18247,12 @@ func (f ValidUntilTimeField) Tag() quickfix.Tag { return tag.ValidUntilTime }
 
 //NewValidUntilTime returns a new ValidUntilTimeField initialized with val
 func NewValidUntilTime(val time.Time) ValidUntilTimeField {
-	return ValidUntilTimeField{quickfix.FIXUTCTimestamp{Value: val}}
+	return ValidUntilTimeField{quickfix.FIXUTCTimestamp{Time: val}}
 }
 
 //NewValidUntilTimeNoMillis returns a new ValidUntilTimeField initialized with val without millisecs
 func NewValidUntilTimeNoMillis(val time.Time) ValidUntilTimeField {
-	return ValidUntilTimeField{quickfix.FIXUTCTimestamp{Value: val, NoMillis: true}}
+	return ValidUntilTimeField{quickfix.FIXUTCTimestamp{Time: val, NoMillis: true}}
 }
 
 //ValuationMethodField is a STRING field

--- a/fix_boolean.go
+++ b/fix_boolean.go
@@ -7,11 +7,8 @@ import (
 //FIXBoolean is a FIX Boolean value, implements FieldValue.
 type FIXBoolean bool
 
-//NewFIXBoolean returns an initialized FIXBoolean
-func NewFIXBoolean(val bool) *FIXBoolean {
-	b := FIXBoolean(val)
-	return &b
-}
+//Bool converts the FIXBoolean value to bool
+func (f FIXBoolean) Bool() bool { return bool(f) }
 
 func (f *FIXBoolean) Read(bytes []byte) error {
 	switch string(bytes) {

--- a/fix_boolean_test.go
+++ b/fix_boolean_test.go
@@ -2,11 +2,13 @@ package quickfix
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestBooleanFieldWrite(t *testing.T) {
-
+func TestBooleanWrite(t *testing.T) {
 	var tests = []struct {
 		val      FIXBoolean
 		expected []byte
@@ -17,14 +19,11 @@ func TestBooleanFieldWrite(t *testing.T) {
 
 	for _, test := range tests {
 		b := test.val.Write()
-
-		if !bytes.Equal(b, test.expected) {
-			t.Errorf("got %v; want %v", b, test.expected)
-		}
+		assert.True(t, bytes.Equal(b, test.expected), fmt.Sprintf("got %v; want %v", b, test.expected))
 	}
 }
 
-func TestFIXBooleanFieldRead(t *testing.T) {
+func TestFIXBooleanRead(t *testing.T) {
 	var tests = []struct {
 		bytes       []byte
 		expected    bool
@@ -39,14 +38,7 @@ func TestFIXBooleanFieldRead(t *testing.T) {
 		var val FIXBoolean
 		err := val.Read(test.bytes)
 
-		if test.expectError && err == nil {
-			t.Errorf("Expected error for %v", test.bytes)
-		} else if !test.expectError && err != nil {
-			t.Errorf("UnExpected '%v'", err)
-		}
-
-		if val != FIXBoolean(test.expected) {
-			t.Errorf("got %v want %v", val, test.expected)
-		}
+		assert.Equal(t, test.expectError, err != nil)
+		assert.Equal(t, test.expected, val.Bool())
 	}
 }

--- a/fix_float.go
+++ b/fix_float.go
@@ -8,11 +8,8 @@ import (
 //FIXFloat is a FIX Float Value, implements FieldValue
 type FIXFloat float64
 
-//NewFIXFloat returns an initialized FIXFloat
-func NewFIXFloat(val float64) *FIXFloat {
-	f := FIXFloat(val)
-	return &f
-}
+//Float64 converts the FIXFloat value to float64
+func (f FIXFloat) Float64() float64 { return float64(f) }
 
 func (f *FIXFloat) Read(bytes []byte) error {
 	val, err := strconv.ParseFloat(string(bytes), 64)

--- a/fix_float_test.go
+++ b/fix_float_test.go
@@ -2,7 +2,10 @@ package quickfix
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFloatWrite(t *testing.T) {
@@ -16,9 +19,7 @@ func TestFloatWrite(t *testing.T) {
 	for _, test := range tests {
 		b := test.field.Write()
 
-		if !bytes.Equal(b, test.val) {
-			t.Errorf("got %v; want %v", b, test.val)
-		}
+		assert.True(t, bytes.Equal(b, test.val), fmt.Sprintf("got %v; want %v", b, test.val))
 	}
 }
 
@@ -40,15 +41,9 @@ func TestFloatRead(t *testing.T) {
 
 	for _, test := range tests {
 		var field FIXFloat
-		if err := field.Read(test.bytes); err != nil {
-			if !test.expectError {
-				t.Errorf("UnExpected '%v'", err)
-			}
-		} else if test.expectError {
-			t.Errorf("Expected error for %v", test.bytes)
-		} else if float64(field) != test.value {
-			t.Errorf("got %v want %v", field, test.value)
-		}
+		err := field.Read(test.bytes)
+		assert.Equal(t, test.expectError, err != nil)
+		assert.Equal(t, test.value, field.Float64())
 	}
 }
 

--- a/fix_int.go
+++ b/fix_int.go
@@ -46,11 +46,8 @@ func parseUInt(d []byte) (n int, err error) {
 //FIXInt is a FIX Int Value, implements FieldValue
 type FIXInt int
 
-//NewFIXInt returns an initialized FIXInt
-func NewFIXInt(val int) *FIXInt {
-	i := FIXInt(val)
-	return &i
-}
+//Int converts the FIXInt value to int
+func (f FIXInt) Int() int { return int(f) }
 
 func (f *FIXInt) Read(bytes []byte) error {
 	i, err := atoi(bytes)

--- a/fix_int_test.go
+++ b/fix_int_test.go
@@ -2,37 +2,32 @@ package quickfix
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestInt_Write(t *testing.T) {
+func TestFIXInt_Write(t *testing.T) {
 	field := FIXInt(5)
-	bytes := field.Write()
 
-	if string(bytes) != "5" {
-		t.Error("Unexpected bytes ", bytes)
-	}
+	assert.Equal(t, "5", string(field.Write()))
 }
 
-func TestInt_Read(t *testing.T) {
+func TestFIXInt_Read(t *testing.T) {
 	var field FIXInt
 	err := field.Read([]byte("15"))
-
-	if err != nil {
-		t.Error("Unexpected error", err)
-	}
-
-	if int(field) != 15 {
-		t.Error("unexpected value", field)
-	}
+	assert.Nil(t, err, "Unexpected error")
+	assert.Equal(t, 15, int(field))
 
 	err = field.Read([]byte("blah"))
-
-	if err == nil {
-		t.Error("expected error")
-	}
+	assert.NotNil(t, err, "Unexpected error")
 }
 
-func BenchmarkInt_Read(b *testing.B) {
+func TestFIXInt_Int(t *testing.T) {
+	f := FIXInt(4)
+	assert.Equal(t, 4, f.Int())
+}
+
+func BenchmarkFIXInt_Read(b *testing.B) {
 	intBytes := []byte("1500")
 	var field FIXInt
 

--- a/fix_string.go
+++ b/fix_string.go
@@ -3,12 +3,6 @@ package quickfix
 //FIXString is a FIX String Value, implements FieldValue
 type FIXString string
 
-//NewFIXString returns an initialized FIXString
-func NewFIXString(val string) *FIXString {
-	s := FIXString(val)
-	return &s
-}
-
 func (f FIXString) String() string {
 	return string(f)
 }

--- a/fix_utc_timestamp.go
+++ b/fix_utc_timestamp.go
@@ -6,7 +6,7 @@ import (
 
 //FIXUTCTimestamp is a FIX UTC Timestamp value, implements FieldValue
 type FIXUTCTimestamp struct {
-	Value    time.Time
+	time.Time
 	NoMillis bool
 }
 
@@ -18,12 +18,12 @@ const (
 func (f *FIXUTCTimestamp) Read(bytes []byte) error {
 	var err error
 	//with millisecs
-	if f.Value, err = time.Parse(utcTimestampFormat, string(bytes)); err == nil {
+	if f.Time, err = time.Parse(utcTimestampFormat, string(bytes)); err == nil {
 		return nil
 	}
 
 	//w/o millisecs
-	if f.Value, err = time.Parse(utcTimestampNoMillisFormat, string(bytes)); err != nil {
+	if f.Time, err = time.Parse(utcTimestampNoMillisFormat, string(bytes)); err != nil {
 		return err
 	}
 
@@ -33,8 +33,8 @@ func (f *FIXUTCTimestamp) Read(bytes []byte) error {
 
 func (f FIXUTCTimestamp) Write() []byte {
 	if f.NoMillis {
-		return []byte(f.Value.UTC().Format(utcTimestampNoMillisFormat))
+		return []byte(f.UTC().Format(utcTimestampNoMillisFormat))
 	}
 
-	return []byte(f.Value.UTC().Format(utcTimestampFormat))
+	return []byte(f.UTC().Format(utcTimestampFormat))
 }

--- a/fix_utc_timestamp_test.go
+++ b/fix_utc_timestamp_test.go
@@ -1,9 +1,10 @@
 package quickfix_test
 
 import (
-	"github.com/quickfixgo/quickfix"
 	"testing"
 	"time"
+
+	"github.com/quickfixgo/quickfix"
 )
 
 func TestFIXUTCTimestampRead(t *testing.T) {
@@ -22,8 +23,8 @@ func TestFIXUTCTimestampRead(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		if !f.Value.Equal(test.expectedTime) {
-			t.Errorf("For Time expected %v got %v", test.expectedTime, f.Value)
+		if !f.Time.Equal(test.expectedTime) {
+			t.Errorf("For Time expected %v got %v", test.expectedTime, f.Time)
 		}
 
 		if f.NoMillis != test.expectedNoMillis {

--- a/gen/generate-fields/main.go
+++ b/gen/generate-fields/main.go
@@ -206,12 +206,12 @@ func (f {{ .Name }}Field) Tag() quickfix.Tag { return tag.{{ .Name }} }
 {{ if eq $base_type "FIXUTCTimestamp" }} 
 //New{{ .Name }} returns a new {{ .Name }}Field initialized with val
 func New{{ .Name }}(val time.Time) {{ .Name }}Field {
-	return {{ .Name }}Field{ quickfix.FIXUTCTimestamp{ Value: val } } 
+	return {{ .Name }}Field{ quickfix.FIXUTCTimestamp{ Time: val } } 
 }
 
 //New{{ .Name }}NoMillis returns a new {{ .Name }}Field initialized with val without millisecs
 func New{{ .Name }}NoMillis(val time.Time) {{ .Name }}Field {
-	return {{ .Name }}Field{ quickfix.FIXUTCTimestamp{ Value: val, NoMillis: true } } 
+	return {{ .Name }}Field{ quickfix.FIXUTCTimestamp{ Time: val, NoMillis: true } } 
 }
 
 {{ else }}

--- a/in_session.go
+++ b/in_session.go
@@ -230,7 +230,7 @@ func (state inSession) doTargetTooLow(session *session, msg Message, rej targetT
 		sendingTime := new(FIXUTCTimestamp)
 		msg.Header.GetField(tagSendingTime, sendingTime)
 
-		if sendingTime.Value.Before(origSendingTime.Value) {
+		if sendingTime.Before(origSendingTime.Time) {
 			session.doReject(msg, sendingTimeAccuracyProblem())
 			return state.initiateLogout(session, "")
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -44,7 +44,7 @@ func (e encoder) encodeValue(fixTag Tag, v reflect.Value, omitEmpty bool, defaul
 	case reflect.Struct:
 		switch t := v.Interface().(type) {
 		case time.Time:
-			e.FieldMap.SetField(fixTag, FIXUTCTimestamp{Value: t})
+			e.FieldMap.SetField(fixTag, FIXUTCTimestamp{Time: t})
 		}
 	case reflect.String:
 		e.FieldMap.SetField(fixTag, FIXString(v.String()))

--- a/session.go
+++ b/session.go
@@ -157,9 +157,9 @@ func (s *session) insertSendingTime(header Header) {
 	sendingTime := time.Now().UTC()
 
 	if s.sessionID.BeginString >= enum.BeginStringFIX42 {
-		header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
+		header.SetField(tagSendingTime, FIXUTCTimestamp{Time: sendingTime})
 	} else {
-		header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime, NoMillis: true})
+		header.SetField(tagSendingTime, FIXUTCTimestamp{Time: sendingTime, NoMillis: true})
 	}
 }
 
@@ -434,7 +434,7 @@ func (s *session) checkSendingTime(msg Message) MessageRejectError {
 		return err
 	}
 
-	if delta := time.Since(sendingTime.Value); delta <= -1*time.Duration(120)*time.Second || delta >= time.Duration(120)*time.Second {
+	if delta := time.Since(sendingTime.Time); delta <= -1*time.Duration(120)*time.Second || delta >= time.Duration(120)*time.Second {
 		return sendingTimeAccuracyProblem()
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -14,6 +14,11 @@ func buildMessage() Message {
 	return builder
 }
 
+func newFIXString(val string) *FIXString {
+	s := FIXString(val)
+	return &s
+}
+
 func TestSession_CheckCorrectCompID(t *testing.T) {
 	session := session{}
 	session.sessionID.TargetCompID = "TAR"
@@ -26,19 +31,19 @@ func TestSession_CheckCorrectCompID(t *testing.T) {
 		rejectReason int
 	}{
 		{returnsError: true, rejectReason: rejectReasonRequiredTagMissing},
-		{senderCompID: NewFIXString("TAR"),
+		{senderCompID: newFIXString("TAR"),
 			returnsError: true,
 			rejectReason: rejectReasonRequiredTagMissing},
-		{senderCompID: NewFIXString("TAR"),
-			targetCompID: NewFIXString("JCD"),
+		{senderCompID: newFIXString("TAR"),
+			targetCompID: newFIXString("JCD"),
 			returnsError: true,
 			rejectReason: rejectReasonCompIDProblem},
-		{senderCompID: NewFIXString("JCD"),
-			targetCompID: NewFIXString("SND"),
+		{senderCompID: newFIXString("JCD"),
+			targetCompID: newFIXString("SND"),
 			returnsError: true,
 			rejectReason: rejectReasonCompIDProblem},
-		{senderCompID: NewFIXString("TAR"),
-			targetCompID: NewFIXString("SND"),
+		{senderCompID: newFIXString("TAR"),
+			targetCompID: newFIXString("SND"),
 			returnsError: false},
 	}
 
@@ -163,7 +168,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 
 	//sending time too late
 	sendingTime := time.Now().Add(time.Duration(-200) * time.Second)
-	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
+	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Time: sendingTime})
 	msgBytes, _ = builder.Build()
 	msg, _ = ParseMessage(msgBytes)
 
@@ -177,7 +182,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 
 	//future sending time
 	sendingTime = time.Now().Add(time.Duration(200) * time.Second)
-	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
+	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Time: sendingTime})
 	msgBytes, _ = builder.Build()
 	msg, _ = ParseMessage(msgBytes)
 
@@ -191,7 +196,7 @@ func TestSession_CheckSendingTime(t *testing.T) {
 
 	//sending time ok
 	sendingTime = time.Now()
-	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: sendingTime})
+	builder.Header.SetField(tagSendingTime, FIXUTCTimestamp{Time: sendingTime})
 	msgBytes, _ = builder.Build()
 	msg, _ = ParseMessage(msgBytes)
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -21,7 +21,7 @@ func (d decoder) decodeValue(fixTag Tag, t reflect.Type, v reflect.Value) Messag
 			if err := d.FieldMap.GetField(Tag(fixTag), fieldValue); err != nil {
 				return err
 			}
-			v.Set(reflect.ValueOf(fieldValue.Value))
+			v.Set(reflect.ValueOf(fieldValue.Time))
 		}
 	case reflect.String:
 		var fieldValue FIXString

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -28,7 +28,7 @@ func TestUnmarshal_Literals(t *testing.T) {
 	fixMsg.Body.SetField(quickfix.Tag(117), quickfix.FIXBoolean(true))
 	fixMsg.Body.SetField(quickfix.Tag(118), quickfix.FIXFloat(500.123))
 	tVal, _ := time.Parse("2006-Jan-02", "2014-Jun-16")
-	fixMsg.Body.SetField(quickfix.Tag(119), quickfix.FIXUTCTimestamp{Value: tVal})
+	fixMsg.Body.SetField(quickfix.Tag(119), quickfix.FIXUTCTimestamp{Time: tVal})
 
 	var msgOut Message
 	quickfix.Unmarshal(fixMsg, &msgOut)
@@ -69,7 +69,7 @@ func TestUnmarshal_LiteralsOptional(t *testing.T) {
 	fixMsg.Body.SetField(quickfix.Tag(115), quickfix.FIXBoolean(false))
 	fixMsg.Body.SetField(quickfix.Tag(116), quickfix.FIXFloat(500.123))
 	tVal, _ := time.Parse("2006-Jan-02", "2014-Jun-16")
-	fixMsg.Body.SetField(quickfix.Tag(117), quickfix.FIXUTCTimestamp{Value: tVal})
+	fixMsg.Body.SetField(quickfix.Tag(117), quickfix.FIXUTCTimestamp{Time: tVal})
 
 	var msgOut Message
 	quickfix.Unmarshal(fixMsg, &msgOut)

--- a/validation_test.go
+++ b/validation_test.go
@@ -81,7 +81,7 @@ func createFIX40NewOrderSingle() Message {
 	msg.Header.SetField(tagSenderCompID, FIXString("0"))
 	msg.Header.SetField(tagTargetCompID, FIXString("0"))
 	msg.Header.SetField(tagMsgSeqNum, FIXString("0"))
-	msg.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: time.Now()})
+	msg.Header.SetField(tagSendingTime, FIXUTCTimestamp{Time: time.Now()})
 
 	msg.Body.SetField(Tag(11), FIXString("A"))
 	msg.Body.SetField(Tag(21), FIXString("1"))
@@ -104,7 +104,7 @@ func createFIX43NewOrderSingle() Message {
 	msg.Header.SetField(tagSenderCompID, FIXString("0"))
 	msg.Header.SetField(tagTargetCompID, FIXString("0"))
 	msg.Header.SetField(tagMsgSeqNum, FIXString("0"))
-	msg.Header.SetField(tagSendingTime, FIXUTCTimestamp{Value: time.Now()})
+	msg.Header.SetField(tagSendingTime, FIXUTCTimestamp{Time: time.Now()})
 
 	msg.Body.SetField(Tag(11), FIXString("A"))
 	msg.Body.SetField(Tag(21), FIXString("1"))
@@ -112,7 +112,7 @@ func createFIX43NewOrderSingle() Message {
 	msg.Body.SetField(Tag(54), FIXString("1"))
 	msg.Body.SetField(Tag(38), FIXInt(5))
 	msg.Body.SetField(Tag(40), FIXString("1"))
-	msg.Body.SetField(Tag(60), FIXUTCTimestamp{Value: time.Now()})
+	msg.Body.SetField(Tag(60), FIXUTCTimestamp{Time: time.Now()})
 
 	msg.Trailer.SetField(tagCheckSum, FIXString("000"))
 
@@ -211,7 +211,7 @@ func tcFieldNotFoundBody() validateTest {
 		SetField(tagSenderCompID, FIXString("0")).
 		SetField(tagTargetCompID, FIXString("0")).
 		SetField(tagMsgSeqNum, FIXString("0")).
-		SetField(tagSendingTime, FIXUTCTimestamp{Value: time.Now()})
+		SetField(tagSendingTime, FIXUTCTimestamp{Time: time.Now()})
 	invalidMsg1.Trailer.SetField(tagCheckSum, FIXString("000"))
 
 	invalidMsg1.Body.SetField(Tag(11), FIXString("A")).


### PR DESCRIPTION
* Removes some archaic field constructors

eg,

```go
f := quickfix.NewFIXString("hello")
```

`NewFIXString` and the other field constructors returned a pointer to the initialized field.  In practice, this isn't normally necessary.  A reference to a FIX field is only necessary when reading a field into a zero-valued field.  

* Adds helper convertors to field types

```go
var cs field.CollStatus
msg.Body.Get(&cs)

//Instead of...
val := int(cs.FIXInt)

//do
val = cs.Int()
```

* Embeds time.Time in FIXUTCTimestamp.  This was previously an unembedded field `Value`.  Embedding has the benefit of calling time.Time methods directly on UTCTimestamp fields.  Note that this change required regenerated fields, c0d827e