### PR TITLE
Do not incr target seq num when seq num too high

### DIFF
--- a/session.go
+++ b/session.go
@@ -315,6 +315,7 @@ func (s *session) handleLogon(msg Message) error {
 		switch TypedError := err.(type) {
 		case targetTooHigh:
 			s.doTargetTooHigh(TypedError)
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Otherwise the response to the resend request will not have the expected seq num.