### PR TITLE
Return requiredConfigurationMissing when "FileStorePath" not found

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -49,7 +49,7 @@ func (f fileStoreFactory) Create(sessionID SessionID) (msgStore MessageStore, er
 	}
 	dirname, err := sessionSettings.Setting(config.FileStorePath)
 	if err != nil {
-		return nil, err
+		return nil, requiredConfigurationMissing(config.FileStorePath)
 	}
 	return newFileStore(sessionID, dirname)
 }


### PR DESCRIPTION
When missing the "FileStorePath" config setting, I was getting an unhelpful "setting not found" error message (returned from session settings). This change follows suit with the behavior in the FileLogFactory