### PR TITLE
Checks around HeartBtInt configuration

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -75,6 +75,10 @@ func NewInitiator(app Application, storeFactory MessageStoreFactory, appSettings
 			return nil, requiredConfigurationMissing(config.SocketConnectPort)
 		}
 
+		if ok := s.HasSetting(config.HeartBtInt); !ok {
+			return nil, requiredConfigurationMissing(config.HeartBtInt)
+		}
+
 		err = createSession(sessionID, storeFactory, s, logFactory, app)
 		if err != nil {
 			return nil, err

--- a/session.go
+++ b/session.go
@@ -107,8 +107,12 @@ func createSession(sessionID SessionID, storeFactory MessageStoreFactory, settin
 	}
 
 	if settings.HasSetting(config.HeartBtInt) {
-		if session.heartBtInt, err = settings.IntSetting(config.HeartBtInt); err != nil {
+		if heartBtInt, err := settings.IntSetting(config.HeartBtInt); err != nil {
 			return err
+		} else if heartBtInt <= 0 {
+			return fmt.Errorf("Heartbeat must be greater than zero")
+		} else {
+			session.heartBtInt = heartBtInt
 		}
 	}
 


### PR DESCRIPTION
Because `HeartBtInt` is a required field on logons, I added a check in the initiator to enforce it as a required configuration option. Without this, my initiator was sending logons with a `HeartBtInt` of `0`, which caused some unexpected behavior in the acceptor.

Additionally, I copied an assertion from QuickFIX/C++, ensuring that `HeartBtInt` is greater than zero.