### PR TITLE
Proper FIX logout sequence

### DIFF
--- a/logout_state.go
+++ b/logout_state.go
@@ -7,13 +7,25 @@ func (state logoutState) String() string { return "Logout State" }
 func (s logoutState) IsLoggedOn() bool   { return false }
 
 func (state logoutState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
-	return state
+	var msgType FIXString
+	if err := msg.Header.GetField(tagMsgType, &msgType); err == nil {
+		switch string(msgType) {
+		//logout
+		case "5":
+			session.log.OnEvent("Received logout response")
+			return latentState{}
+		default:
+			return state
+		}
+	} else {
+		return latentState{}
+	}
 }
 
 func (state logoutState) Timeout(session *session, event event) (nextState sessionState) {
 	switch event {
 	case logoutTimeout:
-		session.log.OnEvent("Timed out waiting for Logout response")
+		session.log.OnEvent("Timed out waiting for logout response")
 		return latentState{}
 	}
 

--- a/logout_state.go
+++ b/logout_state.go
@@ -8,17 +8,17 @@ func (s logoutState) IsLoggedOn() bool   { return false }
 
 func (state logoutState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
 	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err == nil {
-		switch string(msgType) {
-		//logout
-		case "5":
-			session.log.OnEvent("Received logout response")
-			return latentState{}
-		default:
-			return state
-		}
-	} else {
+	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
 		return latentState{}
+	}
+
+	switch string(msgType) {
+	//logout
+	case "5":
+		session.log.OnEvent("Received logout response")
+		return latentState{}
+	default:
+		return state
 	}
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Updates acceptor/initiator stop sequence. Sends a Logout and waits for a response before invoking the application `OnLogout` callback, per FIX standard
- Removes redundant calls to the application `OnLogout` callback. Currently, the `run()` function in `session` ultimately invokes `OnLogout` when it returns, while the `inSession` state has a few cases where it invokes the callback as well.
- Improves the event log output for the logon and logout sequences. Following the QuickFIX/C++ implementation, a proper session event sequence will look like the following:

##### Initiator
```
2016/06/30 15:31:45.167656 Sending logon request
2016/06/30 15:31:45.185684 Received logon response
2016/06/30 15:31:49.810696 Inititated logout request
2016/06/30 15:31:49.825808 Received logout response
2016/06/30 15:31:49.825833 Disconnected
```

##### Acceptor
```
2016/06/30 15:31:45.170768 Received logon request
2016/06/30 15:31:45.182621 Responding to logon request
2016/06/30 15:31:49.814847 Received logout request
2016/06/30 15:31:49.815776 Sending logout response
2016/06/30 15:31:49.827149 Disconnected
```