### PR TITLE
Session event loop follow up

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -39,6 +39,8 @@ func SendToTarget(m Messagable, sessionID SessionID) error {
 	session, err := lookupSession(sessionID)
 	if err != nil {
 		return err
+	} else if session.toSend == nil {
+		return fmt.Errorf("Not logged on")
 	}
 
 	request := sendRequest{msg, make(chan error)}

--- a/session.go
+++ b/session.go
@@ -511,6 +511,7 @@ func (s *session) run(msgIn chan fixIn, msgOut chan []byte, quit chan bool) {
 	defer func() {
 		close(s.messageOut)
 		close(s.toSend)
+		s.toSend = nil
 		s.onDisconnect()
 	}()
 


### PR DESCRIPTION
Two small changes on things that were overlooked on #164

- Bubble up errors returned from message store on send
- Check if session event loop has stopped to avoid sending on a closed channel