### PR TITLE
Reset peer timer after logon

### DIFF
--- a/event_timer.go
+++ b/event_timer.go
@@ -9,14 +9,16 @@ type eventTimer struct {
 	timer *time.Timer
 }
 
-func (t *eventTimer) Reset(timeout time.Duration) (ok bool) {
+func (t *eventTimer) Stop() (ok bool) {
 	if t.timer != nil {
 		ok = t.timer.Stop()
-	} else {
-		ok = true
 	}
+	return
+}
 
-	if t.Task != nil {
+func (t *eventTimer) Reset(timeout time.Duration) (ok bool) {
+	ok = t.Stop()
+	if t.Task != nil && timeout > 0 {
 		t.timer = time.AfterFunc(timeout, t.Task)
 	}
 	return

--- a/session.go
+++ b/session.go
@@ -295,6 +295,8 @@ func (s *session) handleLogon(msg Message) error {
 		s.log.OnEvent("Received logon response")
 	}
 
+	s.peerTimer.Reset(time.Duration(int64(1.2 * float64(s.heartBeatTimeout))))
+
 	if err := s.checkTargetTooHigh(msg); err != nil {
 		switch TypedError := err.(type) {
 		case targetTooHigh:
@@ -511,6 +513,8 @@ func (s *session) run(msgIn chan fixIn, msgOut chan []byte, quit chan bool) {
 		close(s.messageOut)
 		close(s.toSend)
 		s.toSend = nil
+		s.stateTimer.Stop()
+		s.peerTimer.Stop()
 		s.onDisconnect()
 	}()
 


### PR DESCRIPTION
We were seeing a test request (35=1) being sent immediately after logon for our acceptor. After looking into this, it appears that the `peerTimer` was being reset before having processed the logon request form the initiator. Because the initiator's logon contains the heartbeat interval, the acceptor was trying to reset the timer with a zero value, ultimately causing the peer timer to activate immediately.

The following changes will prevent timers from being reset with a zero value, and ensures that the timer is reset once the logon (and heartbeat interval) is received.