### PR TITLE
Ensure OnLogon is called even if seq num too high

### DIFF
--- a/session.go
+++ b/session.go
@@ -308,6 +308,7 @@ func (s *session) handleLogon(msg Message) error {
 	}
 
 	s.peerTimer.Reset(time.Duration(int64(1.2 * float64(s.heartBeatTimeout))))
+	go s.application.OnLogon(s.sessionID)
 
 	if err := s.checkTargetTooHigh(msg); err != nil {
 		switch TypedError := err.(type) {
@@ -318,7 +319,6 @@ func (s *session) handleLogon(msg Message) error {
 	}
 
 	s.store.IncrNextTargetMsgSeqNum()
-	go s.application.OnLogon(s.sessionID)
 	return nil
 }
 


### PR DESCRIPTION
In the case that `checkTargetTooHigh` returns true, we're exiting the logon handling before calling `OnLogon`. Even though a logon immediately starts in the resend state, we should still callback to the application that the logon completed.