### PR TITLE
fixes bogus resend logic

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -162,7 +162,7 @@ func (state inSession) handleResendRequest(session *session, msg Message) (nextS
 	endSeqNo := int(endSeqNoField)
 
 	session.log.OnEventf("Received ResendRequest FROM: %d TO: %d", beginSeqNo, endSeqNo)
-	expectedSeqNum := session.store.NextTargetMsgSeqNum()
+	expectedSeqNum := session.store.NextSenderMsgSeqNum()
 
 	if (session.sessionID.BeginString >= enum.BeginStringFIX42 && endSeqNo == 0) ||
 		(session.sessionID.BeginString <= enum.BeginStringFIX42 && endSeqNo == 999999) ||


### PR DESCRIPTION
Old Code was using the *target* expected sequence number instead of the *sender* expected sequence number to determine resend range.  This resulted in some very peculiar resend states as suggested by #169 