### PR TITLE
Conditionally increment target seq num on resend request

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -174,6 +174,14 @@ func (state inSession) handleResendRequest(session *session, msg Message) (nextS
 		return session.handleError(err)
 	}
 
+	if err := session.checkTargetTooLow(msg); err != nil {
+		return state
+	}
+
+	if err := session.checkTargetTooHigh(msg); err != nil {
+		return state
+	}
+
 	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {
 		return session.handleError(err)
 	}


### PR DESCRIPTION
fixes #169

The cause of the referenced issue was due to the target seq num being incremented while *both* sides were sending the resend request. Therefore when they received the corresponding sequence reset, the sequence of that message was lower than what was erroneously expected. Looking at the quickfix/c++ code, there is in fact a check to prevent this from happening:

https://github.com/quickfix/quickfix/blob/6bc717f88f8e8c3729415a0ec65ec2615d501728/src/C%2B%2B/Session.cpp#L448-L449