### PR TITLE
onlogout calls depend on session state

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -70,7 +70,7 @@ func (state inSession) Timeout(session *session, event internal.Event) (nextStat
 		return pendingTimeout{state}
 	case internal.SessionExpire:
 		session.sendLogoutAndReset()
-		return latentState{}
+		return handleDisconnectState(session)
 	}
 
 	return state
@@ -102,7 +102,7 @@ func (state inSession) handleLogout(session *session, msg Message) (nextState se
 		}
 	}
 
-	return latentState{}
+	return handleDisconnectState(session)
 }
 
 func (state inSession) handleTestRequest(session *session, msg Message) (nextState sessionState) {

--- a/in_session_test.go
+++ b/in_session_test.go
@@ -28,6 +28,7 @@ func (s *InSessionTestSuite) TestIsLoggedOn() {
 func (s *InSessionTestSuite) TestLogout() {
 	s.mockApp.On("FromAdmin").Return(nil)
 	s.mockApp.On("ToAdmin")
+	s.mockApp.On("OnLogout")
 	s.session.FixMsgIn(s.session, s.Logout())
 
 	s.mockApp.AssertExpectations(s.T())
@@ -48,6 +49,7 @@ func (s *InSessionTestSuite) TestLogoutResetOnLogout() {
 
 	s.mockApp.On("FromAdmin").Return(nil)
 	s.mockApp.On("ToAdmin")
+	s.mockApp.On("OnLogout")
 	s.session.FixMsgIn(s.session, s.Logout())
 
 	s.mockApp.AssertExpectations(s.T())
@@ -83,6 +85,13 @@ func (s *InSessionTestSuite) TestTimeoutPeerTimeout() {
 	s.NextSenderMsgSeqNum(2)
 }
 
+func (s *InSessionTestSuite) TestDisconnected() {
+	s.mockApp.On("OnLogout").Return(nil)
+	s.session.Disconnected(s.session)
+	s.mockApp.AssertExpectations(s.T())
+	s.State(latentState{})
+}
+
 func (s *InSessionTestSuite) TestTimeoutSessionExpire() {
 	s.mockApp.On("FromApp").Return(nil)
 	s.FixMsgIn(s.session, s.NewOrderSingle())
@@ -90,6 +99,7 @@ func (s *InSessionTestSuite) TestTimeoutSessionExpire() {
 	s.session.store.IncrNextSenderMsgSeqNum()
 
 	s.mockApp.On("ToAdmin").Return(nil)
+	s.mockApp.On("OnLogout").Return(nil)
 	s.Timeout(s.session, internal.SessionExpire)
 
 	s.mockApp.AssertExpectations(s.T())

--- a/logon_state.go
+++ b/logon_state.go
@@ -28,15 +28,16 @@ func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionSt
 
 func (s logonState) Timeout(session *session, e internal.Event) (nextState sessionState) {
 	switch e {
+	default:
+		return s
+
 	case internal.LogonTimeout:
 		session.log.OnEvent("Timed out waiting for logon response")
-		return latentState{}
 	case internal.SessionExpire:
 		if err := session.dropAndReset(); err != nil {
 			session.logError(err)
 		}
-		return latentState{}
 	}
 
-	return s
+	return handleDisconnectState(session)
 }

--- a/logout_state.go
+++ b/logout_state.go
@@ -18,15 +18,16 @@ func (state logoutState) FixMsgIn(session *session, msg Message) (nextState sess
 
 func (state logoutState) Timeout(session *session, event internal.Event) (nextState sessionState) {
 	switch event {
+	default:
+		return state
+
 	case internal.LogoutTimeout:
 		session.log.OnEvent("Timed out waiting for logout response")
-		return latentState{}
 	case internal.SessionExpire:
 		if err := session.dropAndReset(); err != nil {
 			session.logError(err)
 		}
-		return latentState{}
 	}
 
-	return state
+	return handleDisconnectState(session)
 }

--- a/logout_state_test.go
+++ b/logout_state_test.go
@@ -25,7 +25,10 @@ func (s *LogoutStateTestSuite) TestIsLoggedOn() {
 }
 
 func (s *LogoutStateTestSuite) TestTimeoutLogoutTimeout() {
+	s.mockApp.On("OnLogout").Return(nil)
 	s.Timeout(s.session, internal.LogoutTimeout)
+
+	s.mockApp.AssertExpectations(s.T())
 	s.State(latentState{})
 }
 
@@ -44,12 +47,23 @@ func (s *LogoutStateTestSuite) TestTimeoutSessionExpire() {
 	s.mockApp.AssertExpectations(s.T())
 	s.session.store.IncrNextSenderMsgSeqNum()
 
+	s.mockApp.On("OnLogout").Return(nil)
 	s.Timeout(s.session, internal.SessionExpire)
+
+	s.mockApp.AssertExpectations(s.T())
 	s.State(latentState{})
 	s.NextTargetMsgSeqNum(1)
 	s.NextSenderMsgSeqNum(1)
 	s.NoMessageSent()
 	s.NoMessageQueued()
+}
+
+func (s *LogoutStateTestSuite) TestDisconnected() {
+	s.mockApp.On("OnLogout").Return(nil)
+	s.session.Disconnected(s.session)
+
+	s.mockApp.AssertExpectations(s.T())
+	s.State(latentState{})
 }
 
 func (s *LogoutStateTestSuite) TestFixMsgInNotLogout() {
@@ -76,6 +90,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInNotLogoutReject() {
 
 func (s *LogoutStateTestSuite) TestFixMsgInLogout() {
 	s.mockApp.On("FromAdmin").Return(nil)
+	s.mockApp.On("OnLogout").Return(nil)
 	s.FixMsgIn(s.session, s.Logout())
 
 	s.mockApp.AssertExpectations(s.T())
@@ -93,6 +108,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInLogoutResetOnLogout() {
 	s.mockApp.AssertExpectations(s.T())
 
 	s.mockApp.On("FromAdmin").Return(nil)
+	s.mockApp.On("OnLogout").Return(nil)
 	s.FixMsgIn(s.session, s.Logout())
 
 	s.mockApp.AssertExpectations(s.T())

--- a/pending_timeout.go
+++ b/pending_timeout.go
@@ -8,14 +8,16 @@ type pendingTimeout struct {
 
 func (s pendingTimeout) Timeout(session *session, event internal.Event) (nextState sessionState) {
 	switch event {
+
+	default:
+		return s
+
 	case internal.PeerTimeout:
 		session.log.OnEvent("Session Timeout")
-		return latentState{}
-
 	case internal.SessionExpire:
 		session.sendLogoutAndReset()
-		return latentState{}
 	}
 
-	return s
+	return handleDisconnectState(session)
+
 }

--- a/pending_timeout_test.go
+++ b/pending_timeout_test.go
@@ -28,7 +28,10 @@ func (s *PendingTimeoutTestSuite) TestSessionTimeout() {
 	for _, state := range tests {
 		s.session.State = state
 
+		s.mockApp.On("OnLogout").Return(nil)
 		s.session.Timeout(s.session, internal.PeerTimeout)
+
+		s.mockApp.AssertExpectations(s.T())
 		s.State(latentState{})
 	}
 }
@@ -51,6 +54,23 @@ func (s *PendingTimeoutTestSuite) TestTimeoutUnchangedState() {
 	}
 }
 
+func (s *PendingTimeoutTestSuite) TestDisconnected() {
+	tests := []pendingTimeout{
+		pendingTimeout{inSession{}},
+		pendingTimeout{resendState{}},
+	}
+
+	for _, state := range tests {
+		s.SetupTest()
+		s.session.State = state
+
+		s.mockApp.On("OnLogout").Return(nil)
+		s.session.Disconnected(s.session)
+
+		s.mockApp.AssertExpectations(s.T())
+	}
+}
+
 func (s *PendingTimeoutTestSuite) TestTimeoutSessionExpire() {
 	tests := []pendingTimeout{
 		pendingTimeout{inSession{}},
@@ -69,6 +89,7 @@ func (s *PendingTimeoutTestSuite) TestTimeoutSessionExpire() {
 		s.session.State = state
 
 		s.mockApp.On("ToAdmin").Return(nil)
+		s.mockApp.On("OnLogout").Return(nil)
 		s.Timeout(s.session, internal.SessionExpire)
 
 		s.mockApp.AssertExpectations(s.T())

--- a/session.go
+++ b/session.go
@@ -206,7 +206,6 @@ func (s *session) accept(msgIn chan fixIn, msgOut chan []byte, quit chan bool) {
 
 func (s *session) onDisconnect() {
 	s.log.OnEvent("Disconnected")
-	s.application.OnLogout(s.sessionID)
 }
 
 func (s *session) checkSessionTime(now time.Time) bool {
@@ -749,6 +748,7 @@ func (s *session) run(msgIn chan fixIn, msgOut chan []byte, quit chan bool) {
 			s.sendOrDropAppMessages()
 		case fixIn, ok := <-msgIn:
 			if !ok {
+				s.Disconnected(s)
 				return
 			}
 			s.log.OnIncoming(string(fixIn.bytes))

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -55,6 +55,7 @@ func (e *mockApp) OnLogon(sessionID SessionID) {
 }
 
 func (e *mockApp) OnLogout(sessionID SessionID) {
+	e.Called()
 }
 
 func (e *mockApp) FromAdmin(msg Message, sessionID SessionID) (reject MessageRejectError) {


### PR DESCRIPTION
Guarantees OnLogout is called whenever the session is disconnected and the session is logged on, or is expecting a logon response.  Previously OnLogout was called whenever the session stopped, no matter what the state.