### PR TITLE
checks session time before events outside of ticker

### DIFF
--- a/in_session_test.go
+++ b/in_session_test.go
@@ -37,7 +37,7 @@ func (s *InSessionTestSuite) TestLogout() {
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("ToAdmin")
 	s.MockApp.On("OnLogout")
-	s.session.FixMsgIn(s.session, s.Logout())
+	s.session.fixMsgIn(s.session, s.Logout())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(latentState{})
@@ -58,7 +58,7 @@ func (s *InSessionTestSuite) TestLogoutResetOnLogout() {
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("ToAdmin")
 	s.MockApp.On("OnLogout")
-	s.session.FixMsgIn(s.session, s.Logout())
+	s.session.fixMsgIn(s.session, s.Logout())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(latentState{})

--- a/logon_state_test.go
+++ b/logon_state_test.go
@@ -58,7 +58,7 @@ func (s *LogonStateTestSuite) TestDisconnected() {
 }
 
 func (s *LogonStateTestSuite) TestFixMsgInNotLogon() {
-	s.FixMsgIn(s.session, s.NewOrderSingle())
+	s.fixMsgIn(s.session, s.NewOrderSingle())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(latentState{})
@@ -76,7 +76,7 @@ func (s *LogonStateTestSuite) TestFixMsgInLogon() {
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("OnLogon")
 	s.MockApp.On("ToAdmin")
-	s.FixMsgIn(s.session, logon)
+	s.fixMsgIn(s.session, logon)
 
 	s.MockApp.AssertExpectations(s.T())
 
@@ -102,7 +102,7 @@ func (s *LogonStateTestSuite) TestFixMsgInLogonInitiateLogon() {
 
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("OnLogon")
-	s.FixMsgIn(s.session, logon)
+	s.fixMsgIn(s.session, logon)
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(inSession{})

--- a/logout_state_test.go
+++ b/logout_state_test.go
@@ -53,7 +53,7 @@ func (s *LogoutStateTestSuite) TestDisconnected() {
 
 func (s *LogoutStateTestSuite) TestFixMsgInNotLogout() {
 	s.MockApp.On("FromApp").Return(nil)
-	s.FixMsgIn(s.session, s.NewOrderSingle())
+	s.fixMsgIn(s.session, s.NewOrderSingle())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(logoutState{})
@@ -63,7 +63,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInNotLogout() {
 func (s *LogoutStateTestSuite) TestFixMsgInNotLogoutReject() {
 	s.MockApp.On("FromApp").Return(ConditionallyRequiredFieldMissing(Tag(11)))
 	s.MockApp.On("ToApp").Return(nil)
-	s.FixMsgIn(s.session, s.NewOrderSingle())
+	s.fixMsgIn(s.session, s.NewOrderSingle())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(logoutState{})
@@ -76,7 +76,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInNotLogoutReject() {
 func (s *LogoutStateTestSuite) TestFixMsgInLogout() {
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("OnLogout").Return(nil)
-	s.FixMsgIn(s.session, s.Logout())
+	s.fixMsgIn(s.session, s.Logout())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(latentState{})
@@ -94,7 +94,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInLogoutResetOnLogout() {
 
 	s.MockApp.On("FromAdmin").Return(nil)
 	s.MockApp.On("OnLogout").Return(nil)
-	s.FixMsgIn(s.session, s.Logout())
+	s.fixMsgIn(s.session, s.Logout())
 
 	s.MockApp.AssertExpectations(s.T())
 	s.State(latentState{})


### PR DESCRIPTION
fixes race condition where a message can be received or sent just outside of session time.