### PR TITLE
renames SQLStore config settings

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -31,8 +31,8 @@ const (
 	HeartBtInt               string = "HeartBtInt"
 	FileLogPath              string = "FileLogPath"
 	FileStorePath            string = "FileStorePath"
-	SQLDriver                string = "SQLDriver"
-	SQLDataSourceName        string = "SQLDataSourceName"
-	SQLConnMaxLifetime       string = "SQLConnMaxLifetime"
+	SQLStoreDriver           string = "SQLStoreDriver"
+	SQLStoreDataSourceName   string = "SQLStoreDataSourceName"
+	SQLStoreConnMaxLifetime  string = "SQLStoreConnMaxLifetime"
 	ValidateFieldsOutOfOrder string = "ValidateFieldsOutOfOrder"
 )

--- a/config/doc.go
+++ b/config/doc.go
@@ -211,15 +211,15 @@ FileStorePath
 
 Directory to store sequence number and message files.  Only used with FileStoreFactory.
 
-SQLDriver
+SQLStoreDriver
 
 The name of the database driver to use (see https://github.com/golang/go/wiki/SQLDrivers for the list of available drivers).  Only used with SqlStoreFactory.
 
-SQLDataSourceName
+SQLStoreDataSourceName
 
 The driver-specific data source name of the database to use.  Only used with SqlStoreFactory.
 
-SQLConnMaxLifetime
+SQLStoreConnMaxLifetime
 
 SetConnMaxLifetime sets the maximum duration of time that a database connection may be reused (see https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime).  Defaults to zero, which causes connections to be reused forever.  Only used with SqlStoreFactory.
 

--- a/sqlstore.go
+++ b/sqlstore.go
@@ -32,17 +32,17 @@ func (f sqlStoreFactory) Create(sessionID SessionID) (msgStore MessageStore, err
 	if !ok {
 		return nil, fmt.Errorf("unknown session: %v", sessionID)
 	}
-	sqlDriver, err := sessionSettings.Setting(config.SQLDriver)
+	sqlDriver, err := sessionSettings.Setting(config.SQLStoreDriver)
 	if err != nil {
 		return nil, err
 	}
-	sqlDataSourceName, err := sessionSettings.Setting(config.SQLDataSourceName)
+	sqlDataSourceName, err := sessionSettings.Setting(config.SQLStoreDataSourceName)
 	if err != nil {
 		return nil, err
 	}
 	sqlConnMaxLifetime := 0 * time.Second
-	if sessionSettings.HasSetting(config.SQLConnMaxLifetime) {
-		sqlConnMaxLifetime, err = sessionSettings.DurationSetting(config.SQLConnMaxLifetime)
+	if sessionSettings.HasSetting(config.SQLStoreConnMaxLifetime) {
+		sqlConnMaxLifetime, err = sessionSettings.DurationSetting(config.SQLStoreConnMaxLifetime)
 		if err != nil {
 			return nil, err
 		}

--- a/sqlstore_test.go
+++ b/sqlstore_test.go
@@ -45,9 +45,9 @@ func (suite *SQLStoreTestSuite) SetupTest() {
 	sessionID := SessionID{BeginString: "FIX.4.4", SenderCompID: "SENDER", TargetCompID: "TARGET"}
 	settings, err := ParseSettings(strings.NewReader(fmt.Sprintf(`
 [DEFAULT]
-SQLDriver=%s
-SQLDataSourceName=%s
-SQLConnMaxLifetime=14400s
+SQLStoreDriver=%s
+SQLStoreDataSourceName=%s
+SQLStoreConnMaxLifetime=14400s
 
 [SESSION]
 BeginString=%s


### PR DESCRIPTION
ripping the band aid on this.  naming necessary when SQL Logging configurations are added.