### PR TITLE
fixes bug in resend state where resend response is processed incomplete

### DIFF
--- a/quickfix_test.go
+++ b/quickfix_test.go
@@ -104,6 +104,10 @@ type MessageFactory struct {
 	seqNum int
 }
 
+func (m *MessageFactory) SetNextSeqNum(next int) {
+	m.seqNum = next - 1
+}
+
 func (m *MessageFactory) buildMessage(msgType string) Message {
 	m.seqNum++
 	msg := NewMessage()


### PR DESCRIPTION
Observed behavior is that a peer fufills resend request, but requester appears to ignore caught up messages and issue another subsequent resend request