### PR TITLE
fixes logic around logon message with sequence number too high

### DIFF
--- a/logon_state.go
+++ b/logon_state.go
@@ -36,6 +36,13 @@ func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionSt
 
 			return latentState{}
 
+		case targetTooHigh:
+			if err := session.doTargetTooHigh(err); err != nil {
+				return handleStateError(session, err)
+			}
+
+			return resendState{}
+
 		default:
 			return handleStateError(session, err)
 		}

--- a/session.go
+++ b/session.go
@@ -368,10 +368,7 @@ func (s *session) handleLogon(msg Message) error {
 	s.application.OnLogon(s.sessionID)
 
 	if err := s.checkTargetTooHigh(msg); err != nil {
-		switch TypedError := err.(type) {
-		case targetTooHigh:
-			return s.doTargetTooHigh(TypedError)
-		}
+		return err
 	}
 
 	return s.store.IncrNextTargetMsgSeqNum()


### PR DESCRIPTION
Previously, even though a logon was received with sequence number too high, the state machine would not enter a resend state. However, the resend request would be sent so the peer would be expected to facilitate resend and the resend requester _should_ be unaffected.  In any case, this fixes that logical misstep.