### PR TITLE
Add config.SocketTLSForTesting(bool)

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,7 +15,7 @@ const (
 	SocketPrivateKeyFile     string = "SocketPrivateKeyFile"
 	SocketCertificateFile    string = "SocketCertificateFile"
 	SocketCAFile             string = "SocketCAFile"
-	SocketTLSForTesting      string = "SocketTLSForTesting"
+	SocketInsecureSkipVerify string = "SocketInsecureSkipVerify"
 	DefaultApplVerID         string = "DefaultApplVerID"
 	StartTime                string = "StartTime"
 	EndTime                  string = "EndTime"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,6 +15,7 @@ const (
 	SocketPrivateKeyFile     string = "SocketPrivateKeyFile"
 	SocketCertificateFile    string = "SocketCertificateFile"
 	SocketCAFile             string = "SocketCAFile"
+	SocketTLSForTesting      string = "SocketTLSForTesting"
 	DefaultApplVerID         string = "DefaultApplVerID"
 	StartTime                string = "StartTime"
 	EndTime                  string = "EndTime"

--- a/tls.go
+++ b/tls.go
@@ -11,6 +11,13 @@ import (
 
 func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error) {
 	if !settings.HasSetting(config.SocketPrivateKeyFile) && !settings.HasSetting(config.SocketCertificateFile) {
+		if settings.HasSetting(config.SocketTLSForTesting) {
+			if forTesting, err := settings.BoolSetting(config.SocketTLSForTesting); err == nil {
+				return &tls.Config{InsecureSkipVerify: true}, nil
+			} else if forTesting {
+				return nil, err
+			}
+		}
 		return
 	}
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -87,8 +87,8 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 	s.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 }
 
-func (s *TLSTestSuite) TestTLSForTesting() {
-	s.settings.GlobalSettings().Set(config.SocketTLSForTesting, "Y")
+func (s *TLSTestSuite) TestInsecureSkipVerify() {
+	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
 
 	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
 	s.Nil(err)
@@ -97,15 +97,15 @@ func (s *TLSTestSuite) TestTLSForTesting() {
 	s.True(tlsConfig.InsecureSkipVerify)
 }
 
-func (s *TLSTestSuite) TestTLSForTestingDisableIfCertPresented() {
+func (s *TLSTestSuite) TestInsecureSkipVerifyAndCerts() {
 	s.settings.GlobalSettings().Set(config.SocketPrivateKeyFile, s.PrivateKeyFile)
 	s.settings.GlobalSettings().Set(config.SocketCertificateFile, s.CertificateFile)
-	s.settings.GlobalSettings().Set(config.SocketTLSForTesting, "Y")
+	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
 
 	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
 	s.Nil(err)
 	s.NotNil(tlsConfig)
 
-	s.False(tlsConfig.InsecureSkipVerify)
+	s.True(tlsConfig.InsecureSkipVerify)
 	s.Len(tlsConfig.Certificates, 1)
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -86,3 +86,26 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 	s.NotNil(tlsConfig.ClientCAs)
 	s.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 }
+
+func (s *TLSTestSuite) TestTLSForTesting() {
+	s.settings.GlobalSettings().Set(config.SocketTLSForTesting, "Y")
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+
+	s.True(tlsConfig.InsecureSkipVerify)
+}
+
+func (s *TLSTestSuite) TestTLSForTestingDisableIfCertPresented() {
+	s.settings.GlobalSettings().Set(config.SocketPrivateKeyFile, s.PrivateKeyFile)
+	s.settings.GlobalSettings().Set(config.SocketCertificateFile, s.CertificateFile)
+	s.settings.GlobalSettings().Set(config.SocketTLSForTesting, "Y")
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+
+	s.False(tlsConfig.InsecureSkipVerify)
+	s.Len(tlsConfig.Certificates, 1)
+}


### PR DESCRIPTION
Currently I am working on conformance tests of a FIX service. 
It offers TLS session without CERT info.
So I need to tweak the library to do.

---

FIX servicer may offer to use TLS connection without any CERT info,
basically for conformance testing.

With this switch, the session will use Go's tls.Config
```go
tls.Config{InsecureSkipVerify: true}
```

To prevent accidental behaviour in production service, the switch
only activate if `SocketPrivateKeyFile` and `SocketCertificateFile`
is omitted.