### PR TITLE
Resend logon fix

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -261,13 +261,10 @@ func (state inSession) processReject(session *session, msg Message, rej MessageR
 			nextState = currentState
 
 		default:
-			if err := session.doTargetTooHigh(TypedError); err != nil {
+			var err error
+			if nextState, err = session.doTargetTooHigh(TypedError); err != nil {
 				return handleStateError(session, err)
 			}
-		}
-
-		if nextState.messageStash == nil {
-			nextState.messageStash = make(map[int]Message)
 		}
 
 		nextState.messageStash[TypedError.ReceivedTarget] = msg

--- a/in_session_test.go
+++ b/in_session_test.go
@@ -19,7 +19,6 @@ func TestInSessionTestSuite(t *testing.T) {
 func (s *InSessionTestSuite) SetupTest() {
 	s.Init()
 	s.session.State = inSession{}
-	s.session.messageStash = make(map[int]Message)
 }
 
 func (s *InSessionTestSuite) TestPreliminary() {
@@ -123,10 +122,11 @@ func (s *InSessionTestSuite) TestFIXMsgInTargetTooHigh() {
 	s.MessageType(enum.MsgType_RESEND_REQUEST, s.MockApp.lastToAdmin)
 	s.FieldEquals(tagBeginSeqNo, 1, s.MockApp.lastToAdmin.Body)
 
-	s.State(resendState{})
+	resendState, ok := s.session.State.(resendState)
+	s.True(ok)
 	s.NextTargetMsgSeqNum(1)
 
-	stashedMsg, ok := s.session.messageStash[6]
+	stashedMsg, ok := resendState.messageStash[6]
 	s.True(ok)
 
 	rawMsg, _ := msgSeqNumTooHigh.Build()

--- a/logon_state.go
+++ b/logon_state.go
@@ -37,11 +37,12 @@ func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionSt
 			return latentState{}
 
 		case targetTooHigh:
-			if err := session.doTargetTooHigh(err); err != nil {
-				return handleStateError(session, err)
+			var tooHighErr error
+			if nextState, tooHighErr = session.doTargetTooHigh(err); tooHighErr != nil {
+				return handleStateError(session, tooHighErr)
 			}
 
-			return resendState{}
+			return
 
 		default:
 			return handleStateError(session, err)

--- a/logon_state_test.go
+++ b/logon_state_test.go
@@ -266,4 +266,16 @@ func (s *LogonStateTestSuite) TestFixMsgInLogonSeqNumTooHigh() {
 	s.session.sendQueued()
 	s.MessageType(enum.MsgType_RESEND_REQUEST, s.MockApp.lastToAdmin)
 	s.FieldEquals(tagBeginSeqNo, 1, s.MockApp.lastToAdmin.Body)
+
+	s.MockApp.On("FromAdmin").Return(nil)
+	s.MessageFactory.SetNextSeqNum(1)
+	s.fixMsgIn(s.session, s.SequenceReset(3))
+	s.State(resendState{})
+	s.NextTargetMsgSeqNum(3)
+
+	s.MessageFactory.SetNextSeqNum(3)
+	s.MockApp.On("FromAdmin").Return(nil)
+	s.fixMsgIn(s.session, s.SequenceReset(7))
+	s.State(inSession{})
+	s.NextTargetMsgSeqNum(7)
 }

--- a/quickfix_test.go
+++ b/quickfix_test.go
@@ -209,7 +209,7 @@ func (s *SessionSuiteRig) Init() {
 }
 
 func (s *SessionSuiteRig) State(state sessionState) {
-	s.Equal(state, s.session.State, "session state should be %v", state)
+	s.IsType(state, s.session.State, "session state should be %v", state)
 }
 
 func (s *SessionSuiteRig) MessageSentEquals(msg Message) {

--- a/resend_state_test.go
+++ b/resend_state_test.go
@@ -19,7 +19,6 @@ func TestResendStateTestSuite(t *testing.T) {
 func (s *resendStateTestSuite) SetupTest() {
 	s.Init()
 	s.session.State = resendState{}
-	s.session.messageStash = make(map[int]Message)
 }
 
 func (s *resendStateTestSuite) TestIsLoggedOn() {

--- a/session.go
+++ b/session.go
@@ -31,10 +31,9 @@ type session struct {
 	application  Application
 	validator
 	stateMachine
-	stateTimer   internal.EventTimer
-	peerTimer    internal.EventTimer
-	messageStash map[int]Message
-	sentReset    bool
+	stateTimer internal.EventTimer
+	peerTimer  internal.EventTimer
+	sentReset  bool
 
 	targetDefaultApplVerID string
 
@@ -619,7 +618,6 @@ func (s *session) onAdmin(msg interface{}) {
 
 		s.messageIn = msg.messageIn
 		s.messageOut = msg.messageOut
-		s.messageStash = make(map[int]Message)
 		s.sentReset = false
 
 		s.Connect(s)

--- a/session.go
+++ b/session.go
@@ -301,26 +301,28 @@ func (s *session) sendBytes(msg []byte) {
 	s.stateTimer.Reset(s.HeartBtInt)
 }
 
-func (s *session) doTargetTooHigh(reject targetTooHigh) error {
+func (s *session) doTargetTooHigh(reject targetTooHigh) (nextState resendState, err error) {
 	s.log.OnEventf("MsgSeqNum too high, expecting %v but received %v", reject.ExpectedTarget, reject.ReceivedTarget)
 
 	resend := NewMessage()
 	resend.Header.SetField(tagMsgType, FIXString("2"))
 	resend.Body.SetField(tagBeginSeqNo, FIXInt(reject.ExpectedTarget))
 
-	var endSeqNum = 0
+	var endSeqNum int
 	if s.sessionID.BeginString < enum.BeginStringFIX42 {
 		endSeqNum = 999999
 	}
 	resend.Body.SetField(tagEndSeqNo, FIXInt(endSeqNum))
 
-	if err := s.send(resend); err != nil {
-		return err
+	if err = s.send(resend); err != nil {
+		return
 	}
 
 	s.log.OnEventf("Sent ResendRequest FROM: %v TO: %v", reject.ExpectedTarget, endSeqNum)
+	nextState.messageStash = make(map[int]Message)
+	nextState.resendRangeEnd = reject.ReceivedTarget - 1
 
-	return nil
+	return
 }
 
 func (s *session) handleLogon(msg Message) error {


### PR DESCRIPTION
Fixes bug where a session in resend state after logon with sequence number too high will transition to inSession before receiving all messages in resend request.  Could result in needless resend request if peer doesn't follow normal resend behavior.