### PR TITLE
Add Header.{GetMsgType, HasMsgTypeOf}

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -12,7 +12,7 @@ type inSession struct{ loggedOn }
 func (state inSession) String() string { return "In Session" }
 
 func (state inSession) FixMsgIn(session *session, msg Message) sessionState {
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		return handleStateError(session, err)
 	}

--- a/in_session.go
+++ b/in_session.go
@@ -12,12 +12,12 @@ type inSession struct{ loggedOn }
 func (state inSession) String() string { return "In Session" }
 
 func (state inSession) FixMsgIn(session *session, msg Message) sessionState {
-	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
 		return handleStateError(session, err)
 	}
 
-	switch enum.MsgType(msgType) {
+	switch msgType {
 	case enum.MsgType_LOGON:
 		if err := session.handleLogon(msg); err != nil {
 			if err := session.initiateLogout(""); err != nil {

--- a/logon_state.go
+++ b/logon_state.go
@@ -10,12 +10,12 @@ type logonState struct{ connectedNotLoggedOn }
 func (s logonState) String() string { return "Logon State" }
 
 func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
-	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
 		return handleStateError(session, err)
 	}
 
-	if enum.MsgType(msgType) != enum.MsgType_LOGON {
+	if msgType != enum.MsgType_LOGON {
 		session.log.OnEventf("Invalid Session State: Received Msg %s while waiting for Logon", msg)
 		return latentState{}
 	}

--- a/logon_state.go
+++ b/logon_state.go
@@ -10,7 +10,7 @@ type logonState struct{ connectedNotLoggedOn }
 func (s logonState) String() string { return "Logon State" }
 
 func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		return handleStateError(session, err)
 	}

--- a/message.go
+++ b/message.go
@@ -43,6 +43,23 @@ func (h *Header) Init() {
 	})
 }
 
+// GetMsgType returns MsgType (tag 35) field's value
+func (h *Header) GetMsgType() (msgType enum.MsgType, err MessageRejectError) {
+	var s string
+	if s, err = h.GetString(tagMsgType); err == nil {
+		msgType = enum.MsgType(s)
+	}
+	return
+}
+
+// HasMsgTypeOf returns true if the Header contains MsgType (tag 35) field and its value is the specified one.
+func (h *Header) HasMsgTypeOf(msgType enum.MsgType) bool {
+	if v, err := h.GetMsgType(); err == nil {
+		return v == msgType
+	}
+	return false
+}
+
 //Body is the primary application section of a FIX message
 type Body struct{ FieldMap }
 

--- a/message.go
+++ b/message.go
@@ -43,23 +43,6 @@ func (h *Header) Init() {
 	})
 }
 
-// GetMsgType returns MsgType (tag 35) field's value
-func (h *Header) GetMsgType() (msgType enum.MsgType, err MessageRejectError) {
-	var s string
-	if s, err = h.GetString(tagMsgType); err == nil {
-		msgType = enum.MsgType(s)
-	}
-	return
-}
-
-// HasMsgTypeOf returns true if the Header contains MsgType (tag 35) field and its value is the specified one.
-func (h *Header) HasMsgTypeOf(msgType enum.MsgType) bool {
-	if v, err := h.GetMsgType(); err == nil {
-		return v == msgType
-	}
-	return false
-}
-
 //Body is the primary application section of a FIX message
 type Body struct{ FieldMap }
 
@@ -218,6 +201,23 @@ func ParseMessage(rawMessage []byte) (Message, error) {
 	}
 
 	return msg, nil
+}
+
+// MsgType returns MsgType (tag 35) field's value
+func (m Message) MsgType() (enum.MsgType, MessageRejectError) {
+	s, err := m.Header.GetString(tagMsgType)
+	if err != nil {
+		return enum.MsgType(""), err
+	}
+	return enum.MsgType(s), nil
+}
+
+// IsMsgTypeOf returns true if the Header contains MsgType (tag 35) field and its value is the specified one.
+func (m Message) IsMsgTypeOf(msgType enum.MsgType) bool {
+	if v, err := m.MsgType(); err == nil {
+		return v == msgType
+	}
+	return false
 }
 
 //reverseRoute returns a message builder with routing header fields initialized as the reverse of this message.

--- a/message_router.go
+++ b/message_router.go
@@ -34,7 +34,7 @@ func (c MessageRouter) Route(msg Message, sessionID SessionID) MessageRejectErro
 		return nil
 	}
 
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		return err
 	}

--- a/message_router.go
+++ b/message_router.go
@@ -34,8 +34,8 @@ func (c MessageRouter) Route(msg Message, sessionID SessionID) MessageRejectErro
 		return nil
 	}
 
-	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
 		return err
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -43,7 +43,7 @@ func TestMessage_ParseMessage(t *testing.T) {
 		t.Errorf("Expected %v fields, got %v", expectedLenFields, len(msg.fields))
 	}
 
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		t.Error("Unexpected error, ", err)
 	}
@@ -52,11 +52,11 @@ func TestMessage_ParseMessage(t *testing.T) {
 		t.Errorf("Expected msgType MsgType_ORDER_SINGLE, got %#v", msgType)
 	}
 
-	if !msg.Header.HasMsgTypeOf(enum.MsgType_ORDER_SINGLE) {
+	if !msg.IsMsgTypeOf(enum.MsgType_ORDER_SINGLE) {
 		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_ORDER_SINGLE) is true")
 	}
 
-	if msg.Header.HasMsgTypeOf(enum.MsgType_LOGON) {
+	if msg.IsMsgTypeOf(enum.MsgType_LOGON) {
 		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_LOGON) is false")
 	}
 }

--- a/message_test.go
+++ b/message_test.go
@@ -42,6 +42,23 @@ func TestMessage_ParseMessage(t *testing.T) {
 	if len(msg.fields) != expectedLenFields {
 		t.Errorf("Expected %v fields, got %v", expectedLenFields, len(msg.fields))
 	}
+
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
+		t.Error("Unexpected error, ", err)
+	}
+
+	if msgType != enum.MsgType_ORDER_SINGLE {
+		t.Errorf("Expected msgType MsgType_ORDER_SINGLE, got %#v", msgType)
+	}
+
+	if !msg.Header.HasMsgTypeOf(enum.MsgType_ORDER_SINGLE) {
+		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_ORDER_SINGLE) is true")
+	}
+
+	if msg.Header.HasMsgTypeOf(enum.MsgType_LOGON) {
+		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_LOGON) is false")
+	}
 }
 
 func TestMessage_parseOutOfOrder(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -234,7 +234,7 @@ func (s *session) prepMessageForSend(msg *Message) error {
 	seqNum := s.store.NextSenderMsgSeqNum()
 	msg.Header.SetField(tagMsgSeqNum, FIXInt(seqNum))
 
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		return err
 	}
@@ -465,7 +465,7 @@ func (s *session) verifySelect(msg Message, checkTooHigh bool, checkTooLow bool)
 }
 
 func (s *session) fromCallback(msg Message) MessageRejectError {
-	msgType, err := msg.Header.GetMsgType()
+	msgType, err := msg.MsgType()
 	if err != nil {
 		return err
 	}

--- a/session.go
+++ b/session.go
@@ -234,15 +234,15 @@ func (s *session) prepMessageForSend(msg *Message) error {
 	seqNum := s.store.NextSenderMsgSeqNum()
 	msg.Header.SetField(tagMsgSeqNum, FIXInt(seqNum))
 
-	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
 		return err
 	}
 
 	if isAdminMessageType(string(msgType)) {
 		s.application.ToAdmin(*msg, s.sessionID)
 
-		if enum.MsgType(msgType) == enum.MsgType_LOGON {
+		if msgType == enum.MsgType_LOGON {
 			var resetSeqNumFlag FIXBoolean
 			if msg.Body.Has(tagResetSeqNumFlag) {
 				if err := msg.Body.GetField(tagResetSeqNumFlag, &resetSeqNumFlag); err != nil {
@@ -267,12 +267,11 @@ func (s *session) prepMessageForSend(msg *Message) error {
 		}
 	}
 
-	msgBytes, err := msg.Build()
-	if err == nil {
-		err = s.persist(seqNum, msgBytes)
+	if msgBytes, err := msg.Build(); err != nil {
+		return err
+	} else {
+		return s.persist(seqNum, msgBytes)
 	}
-
-	return err
 }
 
 func (s *session) persist(seqNum int, msgBytes []byte) error {
@@ -466,8 +465,8 @@ func (s *session) verifySelect(msg Message, checkTooHigh bool, checkTooLow bool)
 }
 
 func (s *session) fromCallback(msg Message) MessageRejectError {
-	var msgType FIXString
-	if err := msg.Header.GetField(tagMsgType, &msgType); err != nil {
+	msgType, err := msg.Header.GetMsgType()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Utility methods.

To me, they are useful. How are they to you?
Speaking of the method name  `HasMsgTypeOf`, `IsMsgTypeOf` would be more appropriate? Or more better name we can have?

Thank you.