### PR TITLE
API polish

### DIFF
--- a/file_log.go
+++ b/file_log.go
@@ -14,11 +14,11 @@ type fileLog struct {
 	messageLogger *log.Logger
 }
 
-func (l fileLog) OnIncoming(msg string) {
+func (l fileLog) OnIncoming(msg []byte) {
 	l.messageLogger.Print(msg)
 }
 
-func (l fileLog) OnOutgoing(msg string) {
+func (l fileLog) OnOutgoing(msg []byte) {
 	l.messageLogger.Print(msg)
 }
 

--- a/file_log_test.go
+++ b/file_log_test.go
@@ -107,7 +107,7 @@ func TestFileLog_Append(t *testing.T) {
 	messageScanner := bufio.NewScanner(messageLogFile)
 	eventScanner := bufio.NewScanner(eventLogFile)
 
-	helper.Log.OnIncoming("incoming")
+	helper.Log.OnIncoming([]byte("incoming"))
 	if !messageScanner.Scan() {
 		t.Error("Unexpected EOF")
 	}
@@ -118,7 +118,7 @@ func TestFileLog_Append(t *testing.T) {
 	}
 
 	newHelper := newFileLogHelper(t)
-	newHelper.Log.OnIncoming("incoming")
+	newHelper.Log.OnIncoming([]byte("incoming"))
 	if !messageScanner.Scan() {
 		t.Error("Unexpected EOF")
 	}

--- a/in_session.go
+++ b/in_session.go
@@ -232,10 +232,8 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 		}
 
 		session.log.OnEventf("Resending Message: %v", sentMessageSeqNum)
-		if _, err := msg.Build(); err != nil {
-			return err
-		}
-		session.sendBytes(msg.rawMessage)
+		msgBytes = msg.build()
+		session.sendBytes(msgBytes)
 
 		seqNum = sentMessageSeqNum + 1
 		nextSeqNum = seqNum
@@ -374,10 +372,7 @@ func (state *inSession) generateSequenceReset(session *session, beginSeqNo int, 
 
 	session.application.ToAdmin(sequenceReset, session.sessionID)
 
-	msgBytes, err := sequenceReset.Build()
-	if err != nil {
-		return
-	}
+	msgBytes := sequenceReset.build()
 
 	session.sendBytes(msgBytes)
 	session.log.OnEventf("Sent SequenceReset TO: %v", endSeqNo)

--- a/in_session_test.go
+++ b/in_session_test.go
@@ -160,8 +160,8 @@ func (s *InSessionTestSuite) TestFIXMsgInTargetTooHigh() {
 	stashedMsg, ok := resendState.messageStash[6]
 	s.True(ok)
 
-	rawMsg, _ := msgSeqNumTooHigh.Build()
-	stashedRawMsg, _ := stashedMsg.Build()
+	rawMsg := msgSeqNumTooHigh.build()
+	stashedRawMsg := stashedMsg.build()
 	s.Equal(string(rawMsg), string(stashedRawMsg))
 }
 func (s *InSessionTestSuite) TestFIXMsgInTargetTooHighResendRequestChunkSize() {
@@ -198,8 +198,8 @@ func (s *InSessionTestSuite) TestFIXMsgInTargetTooHighResendRequestChunkSize() {
 		stashedMsg, ok := resendState.messageStash[6]
 		s.True(ok)
 
-		rawMsg, _ := msgSeqNumTooHigh.Build()
-		stashedRawMsg, _ := stashedMsg.Build()
+		rawMsg := msgSeqNumTooHigh.build()
+		stashedRawMsg := stashedMsg.build()
 		s.Equal(string(rawMsg), string(stashedRawMsg))
 	}
 }

--- a/log.go
+++ b/log.go
@@ -3,10 +3,10 @@ package quickfix
 //Log is a generic interface for logging FIX messages and events.
 type Log interface {
 	//log incoming fix message
-	OnIncoming(string)
+	OnIncoming([]byte)
 
 	//log outgoing fix message
-	OnOutgoing(string)
+	OnOutgoing([]byte)
 
 	//log fix event
 	OnEvent(string)

--- a/message.go
+++ b/message.go
@@ -283,8 +283,8 @@ func extractField(parsedFieldBytes *TagValue, buffer []byte) (remBytes []byte, e
 	return buffer[(endIndex + 1):], err
 }
 
-func (m *Message) String() string {
-	return string(m.rawMessage)
+func (m Message) String() string {
+	return string(m.build())
 }
 
 func newCheckSum(value int) FIXString {
@@ -292,17 +292,14 @@ func newCheckSum(value int) FIXString {
 }
 
 //Build constructs a []byte from a Message instance
-func (m *Message) Build() ([]byte, error) {
+func (m Message) build() []byte {
 	m.cook()
 
 	var b bytes.Buffer
 	m.Header.write(&b)
 	m.Body.write(&b)
 	m.Trailer.write(&b)
-
-	m.rawMessage = b.Bytes()
-
-	return m.rawMessage, nil
+	return b.Bytes()
 }
 
 func (m Message) cook() {

--- a/message_test.go
+++ b/message_test.go
@@ -2,8 +2,9 @@ package quickfix
 
 import (
 	"bytes"
-	"github.com/quickfixgo/quickfix/enum"
 	"testing"
+
+	"github.com/quickfixgo/quickfix/enum"
 )
 
 var msgResult Message
@@ -82,11 +83,7 @@ func TestMessage_Build(t *testing.T) {
 	builder.Body.SetField(Tag(554), FIXString("secret"))
 
 	expectedBytes := []byte("8=FIX.4.49=4935=A52=20140615-19:49:56553=my_user554=secret10=072")
-	result, err := builder.Build()
-	if err != nil {
-		t.Error("Unexpected error", err)
-	}
-
+	result := builder.build()
 	if !bytes.Equal(expectedBytes, result) {
 		t.Error("Unexpected bytes, got ", string(result))
 	}
@@ -100,12 +97,12 @@ func TestMessage_ReBuild(t *testing.T) {
 	msg.Header.SetField(tagOrigSendingTime, FIXString("20140515-19:49:56.659"))
 	msg.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
 
-	msg.Build()
+	rebuildBytes := msg.build()
 
 	expectedBytes := []byte("8=FIX.4.29=12635=D34=249=TW52=20140615-19:49:5656=ISLD122=20140515-19:49:56.65911=10021=140=154=155=TSLA60=00010101-00:00:00.00010=128")
 
-	if !bytes.Equal(expectedBytes, msg.rawMessage) {
-		t.Errorf("Unexpected bytes,\n +%s\n-%s", msg.rawMessage, expectedBytes)
+	if !bytes.Equal(expectedBytes, rebuildBytes) {
+		t.Errorf("Unexpected bytes,\n +%s\n-%s", rebuildBytes, expectedBytes)
 	}
 
 	expectedBodyBytes := []byte("11=10021=140=154=155=TSLA60=00010101-00:00:00.000")

--- a/null_log.go
+++ b/null_log.go
@@ -2,9 +2,9 @@ package quickfix
 
 type nullLog struct{}
 
-func (l nullLog) OnIncoming(s string)                      {}
-func (l nullLog) OnOutgoing(s string)                      {}
-func (l nullLog) OnEvent(s string)                         {}
+func (l nullLog) OnIncoming([]byte)                        {}
+func (l nullLog) OnOutgoing([]byte)                        {}
+func (l nullLog) OnEvent(string)                           {}
 func (l nullLog) OnEventf(format string, a ...interface{}) {}
 
 type nullLogFactory struct{}

--- a/quickfix_test.go
+++ b/quickfix_test.go
@@ -46,10 +46,9 @@ func (s *QuickFIXSuite) FieldEquals(tag Tag, expectedValue interface{}, fieldMap
 	}
 }
 
-func (s *QuickFIXSuite) MessageEqualsBytes(msgBytes []byte, msg Message) {
-	_, err := msg.Build()
-	s.Require().Nil(err)
-	s.Equal(string(msg.rawMessage), string(msgBytes))
+func (s *QuickFIXSuite) MessageEqualsBytes(expectedBytes []byte, msg Message) {
+	actualBytes := msg.build()
+	s.Equal(string(actualBytes), string(expectedBytes))
 }
 
 //MockStore wraps a memory store and mocks Refresh for convenience

--- a/screen_log.go
+++ b/screen_log.go
@@ -9,12 +9,12 @@ type screenLog struct {
 	prefix string
 }
 
-func (l screenLog) OnIncoming(s string) {
+func (l screenLog) OnIncoming(s []byte) {
 	logTime := time.Now().UTC()
 	fmt.Printf("<%v, %s, incoming>\n  (%s)\n", logTime, l.prefix, s)
 }
 
-func (l screenLog) OnOutgoing(s string) {
+func (l screenLog) OnOutgoing(s []byte) {
 	logTime := time.Now().UTC()
 	fmt.Printf("<%v, %s, outgoing>\n  (%s)\n", logTime, l.prefix, s)
 }

--- a/session.go
+++ b/session.go
@@ -334,7 +334,7 @@ func (s *session) dropQueued() {
 }
 
 func (s *session) sendBytes(msg []byte) {
-	s.log.OnOutgoing(string(msg))
+	s.log.OnOutgoing(msg)
 	s.messageOut <- msg
 	s.stateTimer.Reset(s.HeartBtInt)
 }

--- a/session_state.go
+++ b/session_state.go
@@ -67,7 +67,7 @@ func (sm *stateMachine) Incoming(session *session, m fixIn) {
 		return
 	}
 
-	session.log.OnIncoming(string(m.bytes))
+	session.log.OnIncoming(m.bytes)
 	if msg, err := ParseMessage(m.bytes); err != nil {
 		session.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), m.bytes)
 	} else {

--- a/session_test.go
+++ b/session_test.go
@@ -410,9 +410,9 @@ func (s *SessionSuite) TestIncomingNotInSessionTime() {
 		}
 
 		msg := s.NewOrderSingle()
-		msg.Build()
+		msgBytes := msg.build()
 
-		s.session.Incoming(s.session, fixIn{bytes: msg.rawMessage})
+		s.session.Incoming(s.session, fixIn{bytes: msgBytes})
 		s.MockApp.AssertExpectations(s.T())
 		s.State(notSessionTime{})
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -125,7 +125,7 @@ func tcInvalidTagNumberHeader() validateTest {
 	invalidHeaderFieldMessage := createFIX40NewOrderSingle()
 	tag := Tag(9999)
 	invalidHeaderFieldMessage.Header.SetField(tag, FIXString("hello"))
-	msgBytes, _ := invalidHeaderFieldMessage.Build()
+	msgBytes := invalidHeaderFieldMessage.build()
 
 	return validateTest{
 		TestName:             "Invalid Tag Number Header",
@@ -141,7 +141,7 @@ func tcInvalidTagNumberBody() validateTest {
 	invalidBodyFieldMessage := createFIX40NewOrderSingle()
 	tag := Tag(9999)
 	invalidBodyFieldMessage.Body.SetField(tag, FIXString("hello"))
-	msgBytes, _ := invalidBodyFieldMessage.Build()
+	msgBytes := invalidBodyFieldMessage.build()
 
 	return validateTest{
 		TestName:             "Invalid Tag Number Body",
@@ -158,7 +158,7 @@ func tcInvalidTagNumberTrailer() validateTest {
 	invalidTrailerFieldMessage := createFIX40NewOrderSingle()
 	tag := Tag(9999)
 	invalidTrailerFieldMessage.Trailer.SetField(tag, FIXString("hello"))
-	msgBytes, _ := invalidTrailerFieldMessage.Build()
+	msgBytes := invalidTrailerFieldMessage.build()
 
 	return validateTest{
 		TestName:             "Invalid Tag Number Trailer",
@@ -175,7 +175,7 @@ func tcTagNotDefinedForMessage() validateTest {
 	invalidMsg := createFIX40NewOrderSingle()
 	tag := Tag(41)
 	invalidMsg.Body.SetField(tag, FIXString("hello"))
-	msgBytes, _ := invalidMsg.Build()
+	msgBytes := invalidMsg.build()
 
 	return validateTest{
 		TestName:             "Tag Not Defined For Message",
@@ -191,7 +191,7 @@ func tcTagIsDefinedForMessage() validateTest {
 	dict, _ := datadictionary.Parse("spec/FIX43.xml")
 	validator := &fixValidator{dict, defaultValidatorSettings}
 	validMsg := createFIX43NewOrderSingle()
-	msgBytes, _ := validMsg.Build()
+	msgBytes := validMsg.build()
 
 	return validateTest{
 		TestName:          "TagIsDefinedForMessage",
@@ -224,7 +224,7 @@ func tcFieldNotFoundBody() validateTest {
 	//ord type is required
 	//invalidMsg1.Body.SetField(Tag(40), "A"))
 
-	msgBytes, _ := invalidMsg1.Build()
+	msgBytes := invalidMsg1.build()
 
 	return validateTest{
 		TestName:             "FieldNotFoundBody",
@@ -257,7 +257,7 @@ func tcFieldNotFoundHeader() validateTest {
 	//invalidMsg2.Header.FieldMap.SetField(tag.SendingTime, "0"))
 
 	tag := tagSendingTime
-	msgBytes, _ := invalidMsg2.Build()
+	msgBytes := invalidMsg2.build()
 
 	return validateTest{
 		TestName:             "FieldNotFoundHeader",
@@ -275,7 +275,7 @@ func tcTagSpecifiedWithoutAValue() validateTest {
 
 	bogusTag := Tag(109)
 	builder.Body.SetField(bogusTag, FIXString(""))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:             "Tag SpecifiedWithoutAValue",
@@ -291,7 +291,7 @@ func tcInvalidMsgType() validateTest {
 	validator := &fixValidator{dict, defaultValidatorSettings}
 	builder := createFIX40NewOrderSingle()
 	builder.Header.SetField(tagMsgType, FIXString("z"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:             "Invalid MsgType",
@@ -308,7 +308,7 @@ func tcValueIsIncorrect() validateTest {
 	tag := Tag(21)
 	builder := createFIX40NewOrderSingle()
 	builder.Body.SetField(tag, FIXString("4"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:             "ValueIsIncorrect",
@@ -325,7 +325,7 @@ func tcIncorrectDataFormatForValue() validateTest {
 	builder := createFIX40NewOrderSingle()
 	tag := Tag(38)
 	builder.Body.SetField(tag, FIXString("+200.00"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:             "IncorrectDataFormatForValue",
@@ -344,7 +344,7 @@ func tcTagSpecifiedOutOfRequiredOrderHeader() validateTest {
 	tag := tagOnBehalfOfCompID
 	//should be in header
 	builder.Body.SetField(tag, FIXString("CWB"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:             "Tag specified out of required order in Header",
@@ -363,7 +363,7 @@ func tcTagSpecifiedOutOfRequiredOrderTrailer() validateTest {
 	tag := tagSignature
 	//should be in trailer
 	builder.Body.SetField(tag, FIXString("SIG"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	refTag := Tag(100)
 	return validateTest{
@@ -384,7 +384,7 @@ func tcTagSpecifiedOutOfRequiredOrderDisabledHeader() validateTest {
 	tag := tagOnBehalfOfCompID
 	//should be in header
 	builder.Body.SetField(tag, FIXString("CWB"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:          "Tag specified out of required order in Header - Disabled",
@@ -403,7 +403,7 @@ func tcTagSpecifiedOutOfRequiredOrderDisabledTrailer() validateTest {
 	tag := tagSignature
 	//should be in trailer
 	builder.Body.SetField(tag, FIXString("SIG"))
-	msgBytes, _ := builder.Build()
+	msgBytes := builder.build()
 
 	return validateTest{
 		TestName:          "Tag specified out of required order in Trailer - Disabled",


### PR DESCRIPTION
* Removes unnecessary string allocation at the top of the Log interface
* remove Build from public Message interface
* consistent receiver on Message methods