### PR TITLE
Using a pool for inbound messages

### DIFF
--- a/acceptor.go
+++ b/acceptor.go
@@ -152,7 +152,8 @@ func (a *Acceptor) handleConnection(netConn net.Conn) {
 		return
 	}
 
-	msg, err := ParseMessage(msgBytes)
+	msg := NewMessage()
+	err = ParseMessage(&msg, msgBytes)
 	if err != nil {
 		a.invalidMessage(msgBytes, err)
 		return

--- a/field_map.go
+++ b/field_map.go
@@ -171,7 +171,9 @@ func (m FieldMap) SetString(tag Tag, value string) FieldMap {
 
 //Clear purges all fields from field map
 func (m *FieldMap) Clear() {
-	m.tagLookup = make(map[Tag]TagValues)
+	for k := range m.tagLookup {
+		delete(m.tagLookup, k)
+	}
 }
 
 //Set is a setter for fields

--- a/in_session.go
+++ b/in_session.go
@@ -210,8 +210,9 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 
 	seqNum := beginSeqNo
 	nextSeqNum := seqNum
+	msg := NewMessage()
 	for _, msgBytes := range msgs {
-		msg, _ := ParseMessage(msgBytes)
+		_ = ParseMessage(&msg, msgBytes)
 		msgType, _ := msg.Header.GetBytes(tagMsgType)
 		sentMessageSeqNum, _ := msg.Header.GetInt(tagMsgSeqNum)
 

--- a/in_session.go
+++ b/in_session.go
@@ -11,7 +11,7 @@ type inSession struct{ loggedOn }
 
 func (state inSession) String() string { return "In Session" }
 
-func (state inSession) FixMsgIn(session *session, msg Message) sessionState {
+func (state inSession) FixMsgIn(session *session, msg *Message) sessionState {
 	msgType, err := msg.Header.GetBytes(tagMsgType)
 	if err != nil {
 		return handleStateError(session, err)
@@ -19,8 +19,8 @@ func (state inSession) FixMsgIn(session *session, msg Message) sessionState {
 
 	switch enum.MsgType(msgType) {
 	case enum.MsgType_LOGON:
-		if err := session.handleLogon(msg); err != nil {
-			if err := session.initiateLogoutInReplyTo("", &msg); err != nil {
+		if err := session.handleLogon(*msg); err != nil {
+			if err := session.initiateLogoutInReplyTo("", msg); err != nil {
 				return handleStateError(session, err)
 			}
 			return logoutState{}
@@ -36,7 +36,7 @@ func (state inSession) FixMsgIn(session *session, msg Message) sessionState {
 	case enum.MsgType_TEST_REQUEST:
 		return state.handleTestRequest(session, msg)
 	default:
-		if err := session.verify(msg); err != nil {
+		if err := session.verify(*msg); err != nil {
 			return state.processReject(session, msg, err)
 		}
 	}
@@ -71,8 +71,8 @@ func (state inSession) Timeout(session *session, event internal.Event) (nextStat
 	return state
 }
 
-func (state inSession) handleLogout(session *session, msg Message) (nextState sessionState) {
-	if err := session.verifySelect(msg, false, false); err != nil {
+func (state inSession) handleLogout(session *session, msg *Message) (nextState sessionState) {
+	if err := session.verifySelect(*msg, false, false); err != nil {
 		return state.processReject(session, msg, err)
 	}
 
@@ -80,7 +80,7 @@ func (state inSession) handleLogout(session *session, msg Message) (nextState se
 		session.log.OnEvent("Received logout request")
 		session.log.OnEvent("Sending logout response")
 
-		if err := session.sendLogoutInReplyTo("", &msg); err != nil {
+		if err := session.sendLogoutInReplyTo("", msg); err != nil {
 			session.logError(err)
 		}
 	} else {
@@ -100,8 +100,8 @@ func (state inSession) handleLogout(session *session, msg Message) (nextState se
 	return latentState{}
 }
 
-func (state inSession) handleTestRequest(session *session, msg Message) (nextState sessionState) {
-	if err := session.verify(msg); err != nil {
+func (state inSession) handleTestRequest(session *session, msg *Message) (nextState sessionState) {
+	if err := session.verify(*msg); err != nil {
 		return state.processReject(session, msg, err)
 	}
 	var testReq FIXString
@@ -111,7 +111,7 @@ func (state inSession) handleTestRequest(session *session, msg Message) (nextSta
 		heartBt := NewMessage()
 		heartBt.Header.SetField(tagMsgType, FIXString("0"))
 		heartBt.Body.SetField(tagTestReqID, testReq)
-		if err := session.sendInReplyTo(heartBt, &msg); err != nil {
+		if err := session.sendInReplyTo(heartBt, msg); err != nil {
 			return handleStateError(session, err)
 		}
 	}
@@ -122,7 +122,7 @@ func (state inSession) handleTestRequest(session *session, msg Message) (nextSta
 	return state
 }
 
-func (state inSession) handleSequenceReset(session *session, msg Message) (nextState sessionState) {
+func (state inSession) handleSequenceReset(session *session, msg *Message) (nextState sessionState) {
 	var gapFillFlag FIXBoolean
 	if msg.Body.Has(tagGapFillFlag) {
 		if err := msg.Body.GetField(tagGapFillFlag, &gapFillFlag); err != nil {
@@ -130,7 +130,7 @@ func (state inSession) handleSequenceReset(session *session, msg Message) (nextS
 		}
 	}
 
-	if err := session.verifySelect(msg, bool(gapFillFlag), bool(gapFillFlag)); err != nil {
+	if err := session.verifySelect(*msg, bool(gapFillFlag), bool(gapFillFlag)); err != nil {
 		return state.processReject(session, msg, err)
 	}
 
@@ -146,7 +146,7 @@ func (state inSession) handleSequenceReset(session *session, msg Message) (nextS
 			}
 		case newSeqNo < expectedSeqNum:
 			//FIXME: to be compliant with legacy tests, do not include tag in reftagid? (11c_NewSeqNoLess)
-			if err := session.doReject(msg, valueIsIncorrectNoTag()); err != nil {
+			if err := session.doReject(*msg, valueIsIncorrectNoTag()); err != nil {
 				return handleStateError(session, err)
 			}
 		}
@@ -154,8 +154,8 @@ func (state inSession) handleSequenceReset(session *session, msg Message) (nextS
 	return state
 }
 
-func (state inSession) handleResendRequest(session *session, msg Message) (nextState sessionState) {
-	if err := session.verifyIgnoreSeqNumTooHighOrLow(msg); err != nil {
+func (state inSession) handleResendRequest(session *session, msg *Message) (nextState sessionState) {
+	if err := session.verifyIgnoreSeqNumTooHighOrLow(*msg); err != nil {
 		return state.processReject(session, msg, err)
 	}
 
@@ -183,15 +183,15 @@ func (state inSession) handleResendRequest(session *session, msg Message) (nextS
 		endSeqNo = expectedSeqNum - 1
 	}
 
-	if err := state.resendMessages(session, int(beginSeqNo), endSeqNo, msg); err != nil {
+	if err := state.resendMessages(session, int(beginSeqNo), endSeqNo, *msg); err != nil {
 		return handleStateError(session, err)
 	}
 
-	if err := session.checkTargetTooLow(msg); err != nil {
+	if err := session.checkTargetTooLow(*msg); err != nil {
 		return state
 	}
 
-	if err := session.checkTargetTooHigh(msg); err != nil {
+	if err := session.checkTargetTooHigh(*msg); err != nil {
 		return state
 	}
 
@@ -249,7 +249,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 	return
 }
 
-func (state inSession) processReject(session *session, msg Message, rej MessageRejectError) sessionState {
+func (state inSession) processReject(session *session, msg *Message, rej MessageRejectError) sessionState {
 	switch TypedError := rej.(type) {
 	case targetTooHigh:
 
@@ -266,10 +266,12 @@ func (state inSession) processReject(session *session, msg Message, rej MessageR
 		}
 
 		if nextState.messageStash == nil {
-			nextState.messageStash = make(map[int]Message)
+			nextState.messageStash = make(map[int]*Message)
 		}
 
 		nextState.messageStash[TypedError.ReceivedTarget] = msg
+		//do not reclaim stashed message
+		msg.keepMessage = true
 
 		return nextState
 
@@ -284,7 +286,7 @@ func (state inSession) processReject(session *session, msg Message, rej MessageR
 
 	switch rej.RejectReason() {
 	case rejectReasonCompIDProblem, rejectReasonSendingTimeAccuracyProblem:
-		if err := session.doReject(msg, rej); err != nil {
+		if err := session.doReject(*msg, rej); err != nil {
 			return handleStateError(session, err)
 		}
 
@@ -293,7 +295,7 @@ func (state inSession) processReject(session *session, msg Message, rej MessageR
 		}
 		return logoutState{}
 	default:
-		if err := session.doReject(msg, rej); err != nil {
+		if err := session.doReject(*msg, rej); err != nil {
 			return handleStateError(session, err)
 		}
 
@@ -304,11 +306,11 @@ func (state inSession) processReject(session *session, msg Message, rej MessageR
 	}
 }
 
-func (state inSession) doTargetTooLow(session *session, msg Message, rej targetTooLow) (nextState sessionState) {
+func (state inSession) doTargetTooLow(session *session, msg *Message, rej targetTooLow) (nextState sessionState) {
 	var posDupFlag FIXBoolean
 	if msg.Header.Has(tagPossDupFlag) {
 		if err := msg.Header.GetField(tagPossDupFlag, &posDupFlag); err != nil {
-			if rejErr := session.doReject(msg, err); rejErr != nil {
+			if rejErr := session.doReject(*msg, err); rejErr != nil {
 				return handleStateError(session, rejErr)
 			}
 			return state
@@ -323,7 +325,7 @@ func (state inSession) doTargetTooLow(session *session, msg Message, rej targetT
 	}
 
 	if !msg.Header.Has(tagOrigSendingTime) {
-		if err := session.doReject(msg, RequiredTagMissing(tagOrigSendingTime)); err != nil {
+		if err := session.doReject(*msg, RequiredTagMissing(tagOrigSendingTime)); err != nil {
 			return handleStateError(session, err)
 		}
 		return state
@@ -331,7 +333,7 @@ func (state inSession) doTargetTooLow(session *session, msg Message, rej targetT
 
 	var origSendingTime FIXUTCTimestamp
 	if err := msg.Header.GetField(tagOrigSendingTime, &origSendingTime); err != nil {
-		if rejErr := session.doReject(msg, err); rejErr != nil {
+		if rejErr := session.doReject(*msg, err); rejErr != nil {
 			return handleStateError(session, rejErr)
 		}
 		return state
@@ -343,7 +345,7 @@ func (state inSession) doTargetTooLow(session *session, msg Message, rej targetT
 	}
 
 	if sendingTime.Before(origSendingTime.Time) {
-		if err := session.doReject(msg, sendingTimeAccuracyProblem()); err != nil {
+		if err := session.doReject(*msg, sendingTimeAccuracyProblem()); err != nil {
 			return handleStateError(session, err)
 		}
 

--- a/in_session_test.go
+++ b/in_session_test.go
@@ -62,7 +62,7 @@ func (s *InSessionTestSuite) TestLogoutResetOnLogout() {
 	s.session.ResetOnLogout = true
 
 	s.MockApp.On("ToApp").Return(nil)
-	s.Nil(s.queueForSend(s.NewOrderSingle()))
+	s.Nil(s.queueForSend(*s.NewOrderSingle()))
 	s.MockApp.AssertExpectations(s.T())
 
 	s.MockApp.On("FromAdmin").Return(nil)
@@ -243,7 +243,7 @@ func (s *InSessionTestSuite) TestFIXMsgInResendRequestAllAdminThenApp() {
 	s.LastToAdminMessageSent()
 
 	s.MockApp.On("ToApp").Return(nil)
-	s.Require().Nil(s.session.send(s.NewOrderSingle()))
+	s.Require().Nil(s.session.send(*s.NewOrderSingle()))
 	s.LastToAppMessageSent()
 
 	s.MockApp.AssertNumberOfCalls(s.T(), "ToAdmin", 2)
@@ -280,7 +280,7 @@ func (s *InSessionTestSuite) TestFIXMsgInResendRequestDoNotSendApp() {
 	s.LastToAdminMessageSent()
 
 	s.MockApp.On("ToApp").Return(nil)
-	s.Require().Nil(s.session.send(s.NewOrderSingle()))
+	s.Require().Nil(s.session.send(*s.NewOrderSingle()))
 	s.LastToAppMessageSent()
 
 	s.session.Timeout(s.session, internal.NeedHeartbeat)

--- a/latent_state.go
+++ b/latent_state.go
@@ -8,7 +8,7 @@ func (state latentState) String() string    { return "Latent State" }
 func (state latentState) IsLoggedOn() bool  { return false }
 func (state latentState) IsConnected() bool { return false }
 
-func (state latentState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
+func (state latentState) FixMsgIn(session *session, msg *Message) (nextState sessionState) {
 	session.log.OnEventf("Invalid Session State: Unexpected Msg %v while in Latent state", msg)
 	return state
 }

--- a/logon_state.go
+++ b/logon_state.go
@@ -9,7 +9,7 @@ type logonState struct{ connectedNotLoggedOn }
 
 func (s logonState) String() string { return "Logon State" }
 
-func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
+func (s logonState) FixMsgIn(session *session, msg *Message) (nextState sessionState) {
 	msgType, err := msg.MsgType()
 	if err != nil {
 		return handleStateError(session, err)
@@ -20,13 +20,13 @@ func (s logonState) FixMsgIn(session *session, msg Message) (nextState sessionSt
 		return latentState{}
 	}
 
-	if err := session.handleLogon(msg); err != nil {
+	if err := session.handleLogon(*msg); err != nil {
 		switch err := err.(type) {
 		case RejectLogon:
 			session.log.OnEvent(err.Text)
 			logout := session.buildLogout(err.Text)
 
-			if err := session.dropAndSendInReplyTo(logout, false, &msg); err != nil {
+			if err := session.dropAndSendInReplyTo(logout, false, msg); err != nil {
 				session.logError(err)
 			}
 

--- a/logon_state_test.go
+++ b/logon_state_test.go
@@ -281,7 +281,8 @@ func (s *LogonStateTestSuite) TestFixMsgInLogonSeqNumTooHigh() {
 	s.MockApp.AssertNumberOfCalls(s.T(), "ToAdmin", 2)
 	msgBytesSent, ok := s.Receiver.LastMessage()
 	s.Require().True(ok)
-	sentMessage, err := ParseMessage(msgBytesSent)
+	sentMessage := NewMessage()
+	err := ParseMessage(&sentMessage, msgBytesSent)
 	s.Require().Nil(err)
 	s.MessageType(enum.MsgType_LOGON, sentMessage)
 

--- a/logout_state.go
+++ b/logout_state.go
@@ -6,7 +6,7 @@ type logoutState struct{ connectedNotLoggedOn }
 
 func (state logoutState) String() string { return "Logout State" }
 
-func (state logoutState) FixMsgIn(session *session, msg Message) (nextState sessionState) {
+func (state logoutState) FixMsgIn(session *session, msg *Message) (nextState sessionState) {
 	nextState = inSession{}.FixMsgIn(session, msg)
 	if nextState, ok := nextState.(latentState); ok {
 		return nextState

--- a/logout_state_test.go
+++ b/logout_state_test.go
@@ -89,7 +89,7 @@ func (s *LogoutStateTestSuite) TestFixMsgInLogoutResetOnLogout() {
 	s.session.ResetOnLogout = true
 
 	s.MockApp.On("ToApp").Return(nil)
-	s.Nil(s.queueForSend(s.NewOrderSingle()))
+	s.Nil(s.queueForSend(*s.NewOrderSingle()))
 	s.MockApp.AssertExpectations(s.T())
 
 	s.MockApp.On("FromAdmin").Return(nil)

--- a/message.go
+++ b/message.go
@@ -89,6 +89,9 @@ type Message struct {
 
 	//field bytes as they appear in the raw message
 	fields TagValues
+
+	//flag is true if this message should not be returned to pool after use
+	keepMessage bool
 }
 
 //ToMessage returns the message itself

--- a/message_pool.go
+++ b/message_pool.go
@@ -1,0 +1,26 @@
+package quickfix
+
+type messagePool struct {
+	m []*Message
+}
+
+func (p *messagePool) New() *Message {
+	msg := NewMessage()
+	return &msg
+}
+
+func (p *messagePool) Get() (msg *Message) {
+	if len(p.m) > 0 {
+		msg, p.m = p.m[len(p.m)-1], p.m[:len(p.m)-1]
+	} else {
+		msg = p.New()
+	}
+
+	msg.keepMessage = false
+
+	return
+}
+
+func (p *messagePool) Put(msg *Message) {
+	p.m = append(p.m, msg)
+}

--- a/message_router_test.go
+++ b/message_router_test.go
@@ -38,18 +38,15 @@ func (suite *MessageRouterTestSuite) givenTheRoute(beginString, msgType string) 
 }
 
 func (suite *MessageRouterTestSuite) givenTheMessage(msgBytes []byte) {
-	msg, err := ParseMessage(msgBytes)
+	err := ParseMessage(&suite.msg, msgBytes)
 	suite.Nil(err)
-	suite.NotNil(msg)
-
-	suite.msg = msg
 
 	var beginString FIXString
-	suite.Require().Nil(msg.Header.GetField(tagBeginString, &beginString))
+	suite.Require().Nil(suite.msg.Header.GetField(tagBeginString, &beginString))
 	var senderCompID FIXString
-	suite.Require().Nil(msg.Header.GetField(tagSenderCompID, &senderCompID))
+	suite.Require().Nil(suite.msg.Header.GetField(tagSenderCompID, &senderCompID))
 	var targetCompID FIXString
-	suite.Require().Nil(msg.Header.GetField(tagTargetCompID, &targetCompID))
+	suite.Require().Nil(suite.msg.Header.GetField(tagTargetCompID, &targetCompID))
 	suite.sessionID = SessionID{BeginString: string(beginString), SenderCompID: string(targetCompID), TargetCompID: string(senderCompID)}
 }
 
@@ -99,6 +96,7 @@ func (suite *MessageRouterTestSuite) SetupTest() {
 	defer sessionsLock.Unlock()
 
 	sessions = make(map[SessionID]*session)
+	suite.msg = NewMessage()
 }
 
 func (suite *MessageRouterTestSuite) TestNoRoute() {

--- a/message_test.go
+++ b/message_test.go
@@ -5,117 +5,96 @@ import (
 	"testing"
 
 	"github.com/quickfixgo/quickfix/enum"
+	"github.com/stretchr/testify/suite"
 )
-
-var msgResult Message
 
 func BenchmarkParseMessage(b *testing.B) {
 	rawMsg := []byte("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 
 	var msg Message
 	for i := 0; i < b.N; i++ {
-		msg, _ = ParseMessage(rawMsg)
+		_ = ParseMessage(&msg, rawMsg)
 	}
-
-	msgResult = msg
 }
 
-func TestMessage_ParseMessage(t *testing.T) {
+type MessageSuite struct {
+	suite.Suite
+	msg Message
+}
+
+func TestMessageSuite(t *testing.T) {
+	suite.Run(t, new(MessageSuite))
+}
+
+func (s *MessageSuite) SetupTest() {
+	s.msg = NewMessage()
+}
+
+func (s *MessageSuite) TestParseMessage() {
 	rawMsg := []byte("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 
-	msg, err := ParseMessage(rawMsg)
+	err := ParseMessage(&s.msg, rawMsg)
+	s.Nil(err)
 
-	if err != nil {
-		t.Error("Unexpected error, ", err)
-	}
-
-	if !bytes.Equal(rawMsg, msg.rawMessage) {
-		t.Error("Expected msg bytes to equal raw bytes")
-	}
+	s.True(bytes.Equal(rawMsg, s.msg.rawMessage), "Expected msg bytes to equal raw bytes")
 
 	expectedBodyBytes := []byte("11=10021=140=154=155=TSLA60=00010101-00:00:00.000")
 
-	if !bytes.Equal(msg.bodyBytes, expectedBodyBytes) {
-		t.Error("Incorrect body bytes, got ", string(msg.bodyBytes))
-	}
+	s.True(bytes.Equal(s.msg.bodyBytes, expectedBodyBytes), "Incorrect body bytes, got %s", string(s.msg.bodyBytes))
 
-	expectedLenFields := 14
-	if len(msg.fields) != expectedLenFields {
-		t.Errorf("Expected %v fields, got %v", expectedLenFields, len(msg.fields))
-	}
+	s.Equal(14, len(s.msg.fields))
 
-	msgType, err := msg.MsgType()
-	if err != nil {
-		t.Error("Unexpected error, ", err)
-	}
+	msgType, err := s.msg.MsgType()
+	s.Nil(err)
 
-	if msgType != enum.MsgType_ORDER_SINGLE {
-		t.Errorf("Expected msgType MsgType_ORDER_SINGLE, got %#v", msgType)
-	}
+	s.Equal(enum.MsgType_ORDER_SINGLE, msgType)
+	s.True(s.msg.IsMsgTypeOf(enum.MsgType_ORDER_SINGLE))
 
-	if !msg.IsMsgTypeOf(enum.MsgType_ORDER_SINGLE) {
-		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_ORDER_SINGLE) is true")
-	}
-
-	if msg.IsMsgTypeOf(enum.MsgType_LOGON) {
-		t.Errorf("Expected Header.HasMsgTypeOf(MsgType_LOGON) is false")
-	}
+	s.False(s.msg.IsMsgTypeOf(enum.MsgType_LOGON))
 }
 
-func TestMessage_parseOutOfOrder(t *testing.T) {
+func (s *MessageSuite) TestParseOutOfOrder() {
 	//allow fields out of order, save for validation
 	rawMsg := []byte("8=FIX.4.09=8135=D11=id21=338=10040=154=155=MSFT34=249=TW52=20140521-22:07:0956=ISLD10=250")
-	_, err := ParseMessage(rawMsg)
-
-	if err != nil {
-		t.Error("Should not have gotten error, got ", err)
-	}
+	s.Nil(ParseMessage(&s.msg, rawMsg))
 }
 
-func TestMessage_Build(t *testing.T) {
-	builder := NewMessage()
+func (s *MessageSuite) TestBuild() {
+	s.msg.Header.SetField(tagBeginString, FIXString(enum.BeginStringFIX44))
+	s.msg.Header.SetField(tagMsgType, FIXString("A"))
+	s.msg.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
 
-	builder.Header.SetField(tagBeginString, FIXString(enum.BeginStringFIX44))
-	builder.Header.SetField(tagMsgType, FIXString("A"))
-	builder.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
-
-	builder.Body.SetField(Tag(553), FIXString("my_user"))
-	builder.Body.SetField(Tag(554), FIXString("secret"))
+	s.msg.Body.SetField(Tag(553), FIXString("my_user"))
+	s.msg.Body.SetField(Tag(554), FIXString("secret"))
 
 	expectedBytes := []byte("8=FIX.4.49=4935=A52=20140615-19:49:56553=my_user554=secret10=072")
-	result := builder.build()
-	if !bytes.Equal(expectedBytes, result) {
-		t.Error("Unexpected bytes, got ", string(result))
-	}
+	result := s.msg.build()
+	s.True(bytes.Equal(expectedBytes, result), "Unexpected bytes, got %s", string(result))
 }
 
-func TestMessage_ReBuild(t *testing.T) {
+func (s *MessageSuite) TestReBuild() {
 	rawMsg := []byte("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 
-	msg, _ := ParseMessage(rawMsg)
+	s.Nil(ParseMessage(&s.msg, rawMsg))
 
-	msg.Header.SetField(tagOrigSendingTime, FIXString("20140515-19:49:56.659"))
-	msg.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
+	s.msg.Header.SetField(tagOrigSendingTime, FIXString("20140515-19:49:56.659"))
+	s.msg.Header.SetField(tagSendingTime, FIXString("20140615-19:49:56"))
 
-	rebuildBytes := msg.build()
+	rebuildBytes := s.msg.build()
 
 	expectedBytes := []byte("8=FIX.4.29=12635=D34=249=TW52=20140615-19:49:5656=ISLD122=20140515-19:49:56.65911=10021=140=154=155=TSLA60=00010101-00:00:00.00010=128")
 
-	if !bytes.Equal(expectedBytes, rebuildBytes) {
-		t.Errorf("Unexpected bytes,\n +%s\n-%s", rebuildBytes, expectedBytes)
-	}
+	s.True(bytes.Equal(expectedBytes, rebuildBytes), "Unexpected bytes,\n +%s\n-%s", rebuildBytes, expectedBytes)
 
 	expectedBodyBytes := []byte("11=10021=140=154=155=TSLA60=00010101-00:00:00.000")
 
-	if !bytes.Equal(msg.bodyBytes, expectedBodyBytes) {
-		t.Error("Incorrect body bytes, got ", string(msg.bodyBytes))
-	}
+	s.True(bytes.Equal(s.msg.bodyBytes, expectedBodyBytes), "Incorrect body bytes, got %s", string(s.msg.bodyBytes))
 }
 
-func TestMessage_reverseRoute(t *testing.T) {
-	msg, _ := ParseMessage([]byte("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
+func (s *MessageSuite) TestReverseRoute() {
+	s.Nil(ParseMessage(&s.msg, []byte("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
 
-	builder := msg.reverseRoute()
+	builder := s.msg.reverseRoute()
 
 	var testCases = []struct {
 		tag           Tag
@@ -137,38 +116,26 @@ func TestMessage_reverseRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		var field FIXString
-		err := builder.Header.GetField(tc.tag, &field)
-		if err != nil {
-			t.Error("Unexpected error, ", err)
-		}
+		s.Nil(builder.Header.GetField(tc.tag, &field))
 
-		if string(field) != tc.expectedValue {
-			t.Errorf("Expected %v got %v", tc.expectedValue, field)
-		}
+		s.Equal(tc.expectedValue, string(field))
 	}
 }
 
-func TestMessage_reverseRouteIgnoreEmpty(t *testing.T) {
-	msg, _ := ParseMessage([]byte("8=FIX.4.09=12835=D34=249=TW52=20060102-15:04:0556=ISLD115=116=CS128=MG129=CB11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
-	builder := msg.reverseRoute()
+func (s *MessageSuite) TestReverseRouteIgnoreEmpty() {
+	s.Nil(ParseMessage(&s.msg, []byte("8=FIX.4.09=12835=D34=249=TW52=20060102-15:04:0556=ISLD115=116=CS128=MG129=CB11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
+	builder := s.msg.reverseRoute()
 
-	if builder.Header.Has(tagDeliverToCompID) {
-		t.Error("Should not reverse if empty")
-	}
+	s.False(builder.Header.Has(tagDeliverToCompID), "Should not reverse if empty")
 }
 
-func TestMessage_reverseRouteFIX40(t *testing.T) {
+func (s *MessageSuite) TestReverseRouteFIX40() {
 	//onbehalfof/deliverto location id not supported in fix 4.0
+	s.Nil(ParseMessage(&s.msg, []byte("8=FIX.4.09=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
 
-	msg, _ := ParseMessage([]byte("8=FIX.4.09=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"))
+	builder := s.msg.reverseRoute()
 
-	builder := msg.reverseRoute()
+	s.False(builder.Header.Has(tagDeliverToLocationID), "delivertolocation id not supported in fix40")
 
-	if builder.Header.Has(tagDeliverToLocationID) {
-		t.Error("delivertolocation id not supported in fix40")
-	}
-
-	if builder.Header.Has(tagOnBehalfOfLocationID) {
-		t.Error("onbehalfof location id not supported in fix40")
-	}
+	s.False(builder.Header.Has(tagOnBehalfOfLocationID), "onbehalfof location id not supported in fix40")
 }

--- a/not_session_time.go
+++ b/not_session_time.go
@@ -7,7 +7,7 @@ type notSessionTime struct{ latentState }
 func (notSessionTime) String() string      { return "Not session time" }
 func (notSessionTime) IsSessionTime() bool { return false }
 
-func (state notSessionTime) FixMsgIn(session *session, msg Message) (nextState sessionState) {
+func (state notSessionTime) FixMsgIn(session *session, msg *Message) (nextState sessionState) {
 	session.log.OnEventf("Invalid Session State: Unexpected Msg %v while in Latent state", msg)
 	return state
 }

--- a/quickfix_test.go
+++ b/quickfix_test.go
@@ -119,7 +119,7 @@ func (m *MessageFactory) SetNextSeqNum(next int) {
 	m.seqNum = next - 1
 }
 
-func (m *MessageFactory) buildMessage(msgType string) Message {
+func (m *MessageFactory) buildMessage(msgType string) *Message {
 	m.seqNum++
 	msg := NewMessage()
 	msg.Header.
@@ -129,26 +129,26 @@ func (m *MessageFactory) buildMessage(msgType string) Message {
 		SetField(tagSendingTime, FIXUTCTimestamp{Time: time.Now()}).
 		SetField(tagMsgSeqNum, FIXInt(m.seqNum)).
 		SetField(tagMsgType, FIXString(msgType))
-	return msg
+	return &msg
 }
 
-func (m *MessageFactory) Logout() Message {
+func (m *MessageFactory) Logout() *Message {
 	return m.buildMessage(string(enum.MsgType_LOGOUT))
 }
 
-func (m *MessageFactory) NewOrderSingle() Message {
+func (m *MessageFactory) NewOrderSingle() *Message {
 	return m.buildMessage(string(enum.MsgType_ORDER_SINGLE))
 }
 
-func (m *MessageFactory) Heartbeat() Message {
+func (m *MessageFactory) Heartbeat() *Message {
 	return m.buildMessage(string(enum.MsgType_HEARTBEAT))
 }
 
-func (m *MessageFactory) Logon() Message {
+func (m *MessageFactory) Logon() *Message {
 	return m.buildMessage(string(enum.MsgType_LOGON))
 }
 
-func (m *MessageFactory) ResendRequest(beginSeqNo int) Message {
+func (m *MessageFactory) ResendRequest(beginSeqNo int) *Message {
 	msg := m.buildMessage(string(enum.MsgType_RESEND_REQUEST))
 	msg.Body.SetField(tagBeginSeqNo, FIXInt(beginSeqNo))
 	msg.Body.SetField(tagEndSeqNo, FIXInt(0))
@@ -156,7 +156,7 @@ func (m *MessageFactory) ResendRequest(beginSeqNo int) Message {
 	return msg
 }
 
-func (m *MessageFactory) SequenceReset(seqNo int) Message {
+func (m *MessageFactory) SequenceReset(seqNo int) *Message {
 	msg := m.buildMessage(string(enum.MsgType_SEQUENCE_RESET))
 	msg.Body.SetField(tagNewSeqNo, FIXInt(seqNo))
 

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -215,7 +215,8 @@ func TestRepeatingGroup_ReadComplete(t *testing.T) {
 
 	rawMsg := []byte("8=FIXT.1.19=26835=W34=711849=TEST52=20151027-18:41:52.69856=TST22=9948=TSTX15262=7268=4269=4270=0.07499272=20151027273=18:41:52.698269=7270=0.07501272=20151027273=18:41:52.698269=8270=0.07494272=20151027273=18:41:52.698269=B271=60272=20151027273=18:41:52.69810=163")
 
-	msg, err := ParseMessage(rawMsg)
+	msg := NewMessage()
+	err := ParseMessage(&msg, rawMsg)
 
 	if err != nil {
 		t.Error("Unexpected error, ", err)

--- a/session.go
+++ b/session.go
@@ -40,6 +40,8 @@ type session struct {
 
 	admin chan interface{}
 	internal.SessionSettings
+
+	messagePool
 }
 
 func (s *session) logError(err error) {

--- a/session_state.go
+++ b/session_state.go
@@ -68,7 +68,9 @@ func (sm *stateMachine) Incoming(session *session, m fixIn) {
 	}
 
 	session.log.OnIncoming(m.bytes)
-	if msg, err := ParseMessage(m.bytes); err != nil {
+
+	msg := NewMessage()
+	if err := ParseMessage(&msg, m.bytes); err != nil {
 		session.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), m.bytes)
 	} else {
 		msg.ReceiveTime = m.receiveTime

--- a/session_state.go
+++ b/session_state.go
@@ -69,17 +69,21 @@ func (sm *stateMachine) Incoming(session *session, m fixIn) {
 
 	session.log.OnIncoming(m.bytes)
 
-	msg := NewMessage()
-	if err := ParseMessage(&msg, m.bytes); err != nil {
+	msg := session.messagePool.Get()
+	if err := ParseMessage(msg, m.bytes); err != nil {
 		session.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), m.bytes)
 	} else {
 		msg.ReceiveTime = m.receiveTime
 		sm.fixMsgIn(session, msg)
 	}
+
+	if !msg.keepMessage {
+		session.messagePool.Put(msg)
+	}
 	session.peerTimer.Reset(time.Duration(float64(1.2) * float64(session.HeartBtInt)))
 }
 
-func (sm *stateMachine) fixMsgIn(session *session, m Message) {
+func (sm *stateMachine) fixMsgIn(session *session, m *Message) {
 	sm.setState(session, sm.State.FixMsgIn(session, m))
 }
 
@@ -195,7 +199,7 @@ func handleStateError(s *session, err error) sessionState {
 type sessionState interface {
 	//FixMsgIn is called by the session on incoming messages from the counter party.  The return type is the next session state
 	//following message processing
-	FixMsgIn(*session, Message) (nextState sessionState)
+	FixMsgIn(*session, *Message) (nextState sessionState)
 
 	//Timeout is called by the session on a timeout event.
 	Timeout(*session, internal.Event) (nextState sessionState)

--- a/session_test.go
+++ b/session_test.go
@@ -449,7 +449,7 @@ func (s *SessionSuite) TestSendAppMessagesNotInSessionTime() {
 		s.IncrNextTargetMsgSeqNum()
 
 		s.MockApp.On("ToApp").Return(nil)
-		s.Require().Nil(s.queueForSend(s.NewOrderSingle()))
+		s.Require().Nil(s.queueForSend(*s.NewOrderSingle()))
 		s.MockApp.AssertExpectations(s.T())
 
 		now := time.Now().UTC()
@@ -670,7 +670,7 @@ func (suite *SessionSendTestSuite) SetupTest() {
 
 func (suite *SessionSendTestSuite) TestQueueForSendAppMessage() {
 	suite.MockApp.On("ToApp").Return(nil)
-	require.Nil(suite.T(), suite.queueForSend(suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.NewOrderSingle()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.NoMessageSent()
@@ -681,7 +681,7 @@ func (suite *SessionSendTestSuite) TestQueueForSendAppMessage() {
 
 func (suite *SessionSendTestSuite) TestQueueForSendDoNotSendAppMessage() {
 	suite.MockApp.On("ToApp").Return(ErrDoNotSend)
-	suite.Equal(ErrDoNotSend, suite.queueForSend(suite.NewOrderSingle()))
+	suite.Equal(ErrDoNotSend, suite.queueForSend(*suite.NewOrderSingle()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.NoMessagePersisted(1)
@@ -689,7 +689,7 @@ func (suite *SessionSendTestSuite) TestQueueForSendDoNotSendAppMessage() {
 	suite.NextSenderMsgSeqNum(1)
 
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.send(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.send(*suite.Heartbeat()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.LastToAdminMessageSent()
@@ -699,7 +699,7 @@ func (suite *SessionSendTestSuite) TestQueueForSendDoNotSendAppMessage() {
 
 func (suite *SessionSendTestSuite) TestQueueForSendAdminMessage() {
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.queueForSend(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.Heartbeat()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.MessagePersisted(suite.MockApp.lastToAdmin)
@@ -709,7 +709,7 @@ func (suite *SessionSendTestSuite) TestQueueForSendAdminMessage() {
 
 func (suite *SessionSendTestSuite) TestSendAppMessage() {
 	suite.MockApp.On("ToApp").Return(nil)
-	require.Nil(suite.T(), suite.send(suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.send(*suite.NewOrderSingle()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.MessagePersisted(suite.MockApp.lastToApp)
@@ -719,7 +719,7 @@ func (suite *SessionSendTestSuite) TestSendAppMessage() {
 
 func (suite *SessionSendTestSuite) TestSendAppDoNotSendMessage() {
 	suite.MockApp.On("ToApp").Return(ErrDoNotSend)
-	suite.Equal(ErrDoNotSend, suite.send(suite.NewOrderSingle()))
+	suite.Equal(ErrDoNotSend, suite.send(*suite.NewOrderSingle()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.NextSenderMsgSeqNum(1)
@@ -728,7 +728,7 @@ func (suite *SessionSendTestSuite) TestSendAppDoNotSendMessage() {
 
 func (suite *SessionSendTestSuite) TestSendAdminMessage() {
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.send(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.send(*suite.Heartbeat()))
 	suite.MockApp.AssertExpectations(suite.T())
 
 	suite.LastToAdminMessageSent()
@@ -738,8 +738,8 @@ func (suite *SessionSendTestSuite) TestSendAdminMessage() {
 func (suite *SessionSendTestSuite) TestSendFlushesQueue() {
 	suite.MockApp.On("ToApp").Return(nil)
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.queueForSend(suite.NewOrderSingle()))
-	require.Nil(suite.T(), suite.queueForSend(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.Heartbeat()))
 
 	order1 := suite.MockApp.lastToApp
 	heartbeat := suite.MockApp.lastToAdmin
@@ -748,7 +748,7 @@ func (suite *SessionSendTestSuite) TestSendFlushesQueue() {
 	suite.NoMessageSent()
 
 	suite.MockApp.On("ToApp").Return(nil)
-	require.Nil(suite.T(), suite.send(suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.send(*suite.NewOrderSingle()))
 	suite.MockApp.AssertExpectations(suite.T())
 	order2 := suite.MockApp.lastToApp
 	suite.MessageSentEquals(order1)
@@ -760,8 +760,8 @@ func (suite *SessionSendTestSuite) TestSendFlushesQueue() {
 func (suite *SessionSendTestSuite) TestSendNotLoggedOn() {
 	suite.MockApp.On("ToApp").Return(nil)
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.queueForSend(suite.NewOrderSingle()))
-	require.Nil(suite.T(), suite.queueForSend(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.Heartbeat()))
 
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.NoMessageSent()
@@ -771,7 +771,7 @@ func (suite *SessionSendTestSuite) TestSendNotLoggedOn() {
 	for _, test := range tests {
 		suite.MockApp.On("ToApp").Return(nil)
 		suite.session.State = test
-		require.Nil(suite.T(), suite.send(suite.NewOrderSingle()))
+		require.Nil(suite.T(), suite.send(*suite.NewOrderSingle()))
 		suite.MockApp.AssertExpectations(suite.T())
 		suite.NoMessageSent()
 	}
@@ -784,7 +784,7 @@ func (suite *SessionSendTestSuite) TestSendEnableLastMsgSeqNumProcessed() {
 	suite.Require().Nil(suite.session.store.SetNextTargetMsgSeqNum(45))
 
 	suite.MockApp.On("ToApp").Return(nil)
-	require.Nil(suite.T(), suite.send(suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.send(*suite.NewOrderSingle()))
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.LastToAppMessageSent()
 
@@ -793,7 +793,7 @@ func (suite *SessionSendTestSuite) TestSendEnableLastMsgSeqNumProcessed() {
 
 func (suite *SessionSendTestSuite) TestDropAndSendAdminMessage() {
 	suite.MockApp.On("ToAdmin")
-	suite.Require().Nil(suite.dropAndSend(suite.Heartbeat(), false))
+	suite.Require().Nil(suite.dropAndSend(*suite.Heartbeat(), false))
 	suite.MockApp.AssertExpectations(suite.T())
 
 	suite.MessagePersisted(suite.MockApp.lastToAdmin)
@@ -803,14 +803,14 @@ func (suite *SessionSendTestSuite) TestDropAndSendAdminMessage() {
 func (suite *SessionSendTestSuite) TestDropAndSendDropsQueue() {
 	suite.MockApp.On("ToApp").Return(nil)
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.queueForSend(suite.NewOrderSingle()))
-	require.Nil(suite.T(), suite.queueForSend(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.Heartbeat()))
 	suite.MockApp.AssertExpectations(suite.T())
 
 	suite.NoMessageSent()
 
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.dropAndSend(suite.Logon(), false))
+	require.Nil(suite.T(), suite.dropAndSend(*suite.Logon(), false))
 	suite.MockApp.AssertExpectations(suite.T())
 
 	msg := suite.MockApp.lastToAdmin
@@ -825,13 +825,13 @@ func (suite *SessionSendTestSuite) TestDropAndSendDropsQueue() {
 func (suite *SessionSendTestSuite) TestDropAndSendDropsQueueWithReset() {
 	suite.MockApp.On("ToApp").Return(nil)
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.queueForSend(suite.NewOrderSingle()))
-	require.Nil(suite.T(), suite.queueForSend(suite.Heartbeat()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.NewOrderSingle()))
+	require.Nil(suite.T(), suite.queueForSend(*suite.Heartbeat()))
 	suite.MockApp.AssertExpectations(suite.T())
 	suite.NoMessageSent()
 
 	suite.MockApp.On("ToAdmin")
-	require.Nil(suite.T(), suite.dropAndSend(suite.Logon(), true))
+	require.Nil(suite.T(), suite.dropAndSend(*suite.Logon(), true))
 	suite.MockApp.AssertExpectations(suite.T())
 	msg := suite.MockApp.lastToAdmin
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/quickfixgo/quickfix/datadictionary"
+	"github.com/stretchr/testify/assert"
 )
 
 type validateTest struct {
@@ -37,8 +38,9 @@ func TestValidate(t *testing.T) {
 		tcFieldNotFoundHeader(),
 	}
 
+	msg := NewMessage()
 	for _, test := range tests {
-		msg, _ := ParseMessage(test.MessageBytes)
+		assert.Nil(t, ParseMessage(&msg, test.MessageBytes))
 		reject := test.Validator.Validate(msg)
 
 		switch {


### PR DESCRIPTION
Drastically reduces the number of allocations for inbound messages