### PR TITLE
message.String() returns rawMessage if set, builds otherwise

### DIFF
--- a/message.go
+++ b/message.go
@@ -295,6 +295,10 @@ func extractField(parsedFieldBytes *TagValue, buffer []byte) (remBytes []byte, e
 }
 
 func (m Message) String() string {
+	if m.rawMessage != nil {
+		return string(m.rawMessage)
+	}
+
 	return string(m.build())
 }
 


### PR DESCRIPTION
This is necessary to get on the wire string format for group messages.

Fixes issue introduced in #260