### PR TITLE
use data dictionary for parsing fix messages

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -213,7 +213,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 	nextSeqNum := seqNum
 	msg := NewMessage()
 	for _, msgBytes := range msgs {
-		_ = ParseMessage(msg, bytes.NewBuffer(msgBytes))
+		_ = ParseMessageWithDataDictionary(msg, bytes.NewBuffer(msgBytes), session.transportDataDictionary, session.appDataDictionary)
 		msgType, _ := msg.Header.GetBytes(tagMsgType)
 		sentMessageSeqNum, _ := msg.Header.GetInt(tagMsgSeqNum)
 

--- a/message_test.go
+++ b/message_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/quickfixgo/quickfix/datadictionary"
 	"github.com/quickfixgo/quickfix/enum"
 	"github.com/stretchr/testify/suite"
 )
@@ -18,7 +19,7 @@ func BenchmarkParseMessage(b *testing.B) {
 }
 
 type MessageSuite struct {
-	suite.Suite
+	QuickFIXSuite
 	msg *Message
 }
 
@@ -51,6 +52,26 @@ func (s *MessageSuite) TestParseMessage() {
 	s.True(s.msg.IsMsgTypeOf(enum.MsgType_ORDER_SINGLE))
 
 	s.False(s.msg.IsMsgTypeOf(enum.MsgType_LOGON))
+}
+
+func (s *MessageSuite) TestParseMessageWithDataDictionary() {
+	dict := new(datadictionary.DataDictionary)
+	dict.Header = &datadictionary.MessageDef{
+		Fields: map[int]*datadictionary.FieldDef{
+			10030: nil,
+		},
+	}
+	dict.Trailer = &datadictionary.MessageDef{
+		Fields: map[int]*datadictionary.FieldDef{
+			5050: nil,
+		},
+	}
+	rawMsg := bytes.NewBufferString("8=FIX.4.29=12635=D34=249=TW52=20140515-19:49:56.65956=ISLD10030=CUST11=10021=140=154=155=TSLA60=00010101-00:00:00.0005050=HELLO10=039")
+
+	err := ParseMessageWithDataDictionary(s.msg, rawMsg, dict, dict)
+	s.Nil(err)
+	s.FieldEquals(Tag(10030), "CUST", s.msg.Header)
+	s.FieldEquals(Tag(5050), "HELLO", s.msg.Trailer)
 }
 
 func (s *MessageSuite) TestParseOutOfOrder() {

--- a/session.go
+++ b/session.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/quickfixgo/quickfix/datadictionary"
 	"github.com/quickfixgo/quickfix/enum"
 	"github.com/quickfixgo/quickfix/internal"
 )
@@ -40,6 +41,8 @@ type session struct {
 
 	admin chan interface{}
 	internal.SessionSettings
+	transportDataDictionary *datadictionary.DataDictionary
+	appDataDictionary       *datadictionary.DataDictionary
 
 	messagePool
 }

--- a/session_factory.go
+++ b/session_factory.go
@@ -97,16 +97,15 @@ func (f sessionFactory) newSession(
 				return
 			}
 
-			var transportDataDictionary, appDataDictionary *datadictionary.DataDictionary
-			if transportDataDictionary, err = datadictionary.Parse(transportDataDictionaryPath); err != nil {
+			if s.transportDataDictionary, err = datadictionary.Parse(transportDataDictionaryPath); err != nil {
 				return
 			}
 
-			if appDataDictionary, err = datadictionary.Parse(appDataDictionaryPath); err != nil {
+			if s.appDataDictionary, err = datadictionary.Parse(appDataDictionaryPath); err != nil {
 				return
 			}
 
-			s.validator = &fixtValidator{transportDataDictionary, appDataDictionary, validatorSettings}
+			s.validator = &fixtValidator{s.transportDataDictionary, s.appDataDictionary, validatorSettings}
 		}
 	} else if settings.HasSetting(config.DataDictionary) {
 		var dataDictionaryPath string
@@ -114,12 +113,11 @@ func (f sessionFactory) newSession(
 			return
 		}
 
-		var dataDictionary *datadictionary.DataDictionary
-		if dataDictionary, err = datadictionary.Parse(dataDictionaryPath); err != nil {
+		if s.appDataDictionary, err = datadictionary.Parse(dataDictionaryPath); err != nil {
 			return
 		}
 
-		s.validator = &fixValidator{dataDictionary, validatorSettings}
+		s.validator = &fixValidator{s.appDataDictionary, validatorSettings}
 	}
 
 	if settings.HasSetting(config.ResetOnLogon) {

--- a/session_state.go
+++ b/session_state.go
@@ -70,7 +70,7 @@ func (sm *stateMachine) Incoming(session *session, m fixIn) {
 	session.log.OnIncoming(m.bytes.Bytes())
 
 	msg := session.messagePool.Get()
-	if err := ParseMessage(msg, m.bytes); err != nil {
+	if err := ParseMessageWithDataDictionary(msg, m.bytes, session.transportDataDictionary, session.appDataDictionary); err != nil {
 		session.log.OnEventf("Msg Parse Error: %v, %q", err.Error(), m.bytes)
 	} else {
 		msg.ReceiveTime = m.receiveTime


### PR DESCRIPTION
Incremental change to support #276. Allows data dictionary to help parse custom header and trailer fields in the Header and Trailer FieldMaps respectively.