### PR TITLE
Use timestamp with time zone for postgres sql

### DIFF
--- a/_sql/postgresql/event_log_table.sql
+++ b/_sql/postgresql/event_log_table.sql
@@ -2,7 +2,7 @@ CREATE SEQUENCE event_log_sequence;
 
 CREATE TABLE event_log (
   id INTEGER DEFAULT NEXTVAL('event_log_sequence'),
-  time TIMESTAMP NOT NULL,
+  time TIMESTAMP WITH TIME ZONE NOT NULL,
   beginstring CHAR(8) NOT NULL,
   sendercompid VARCHAR(64) NOT NULL,
   sendersubid VARCHAR(64) NOT NULL,

--- a/_sql/postgresql/messages_log_table.sql
+++ b/_sql/postgresql/messages_log_table.sql
@@ -2,7 +2,7 @@ CREATE SEQUENCE messages_log_sequence;
 
 CREATE TABLE messages_log (
   id INTEGER DEFAULT NEXTVAL('messages_log_sequence'),
-  time TIMESTAMP NOT NULL,
+  time TIMESTAMP WITH TIME ZONE NOT NULL,
   beginstring CHAR(8) NOT NULL,
   sendercompid VARCHAR(64) NOT NULL,
   sendersubid VARCHAR(64) NOT NULL,

--- a/_sql/postgresql/sessions_table.sql
+++ b/_sql/postgresql/sessions_table.sql
@@ -7,7 +7,7 @@ CREATE TABLE sessions (
   targetsubid VARCHAR(64) NOT NULL,
   targetlocid VARCHAR(64) NOT NULL,
   session_qualifier VARCHAR(64) NOT NULL,
-  creation_time TIMESTAMP NOT NULL,
+  creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
   incoming_seqnum INTEGER NOT NULL, 
   outgoing_seqnum INTEGER NOT NULL,
   PRIMARY KEY (beginstring, sendercompid, sendersubid, senderlocid, 


### PR DESCRIPTION
Without time zone:
- When creation_time is saved to db, it is save as local time e.g `+0200 EET`
- When creation_time is read from db, it is read as `+0000 +0000`
E.g:
1. creation_time is initialized: `2014-03-26 17:05:30.889109334 +0200 EET`
2. Save into db it becomes: `2014-03-26 17:05:30.889109`
3. Read from db to creation_time, it becomes: `2014-03-26 17:05:30.889109 +0000 +0000`

=> (1) != (3)

With time zone: (1) == (3)

Reference: https://github.com/lib/pq/pull/247#issuecomment-38695036
