### PR TITLE
header and trailer templates use rootpath

### DIFF
--- a/cmd/generate-fix/internal/templates.go
+++ b/cmd/generate-fix/internal/templates.go
@@ -168,10 +168,10 @@ import(
 
 	"github.com/quickfixgo/quickfix"
 	{{- if checkIfEnumImportRequired .MessageDef}}
-	"github.com/quickfixgo/quickfix/enum"
+	"{{ importRootPath }}/enum"
 	{{- end }}
-	"github.com/quickfixgo/quickfix/field"
-	"github.com/quickfixgo/quickfix/tag"
+	"{{ importRootPath }}/field"
+	"{{ importRootPath }}/tag"
 )
 
 //Header is the {{ .Package }} Header type
@@ -203,10 +203,10 @@ import(
 
 	"github.com/quickfixgo/quickfix"
 	{{- if checkIfEnumImportRequired .MessageDef}}
-	"github.com/quickfixgo/quickfix/enum"
+	"{{ importRootPath }}/enum"
 	{{- end }}
-	"github.com/quickfixgo/quickfix/field"
-	"github.com/quickfixgo/quickfix/tag"
+	"{{ importRootPath }}/field"
+	"{{ importRootPath }}/tag"
 )
 
 //Trailer is the {{ .Package }} Trailer type


### PR DESCRIPTION
Header and Trailer templates were not using ImportRootPath for importing generated enums, fields and tag packages.  This change will allow generated header and trailer types to use custom fields not in the quickfix packaged generated types.