### PR TITLE
adds validation to datadictionary builder

### DIFF
--- a/datadictionary/build_test.go
+++ b/datadictionary/build_test.go
@@ -2,8 +2,117 @@ package datadictionary
 
 import (
 	"encoding/xml"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
+
+type BuildSuite struct {
+	suite.Suite
+	doc *XMLDoc
+	*builder
+}
+
+func TestBuildSuite(t *testing.T) {
+	suite.Run(t, new(BuildSuite))
+}
+
+func (s *BuildSuite) SetupTest() {
+	s.doc = &XMLDoc{Type: "FIX", Major: "4", Minor: "5"}
+	s.builder = new(builder)
+}
+
+func (s *BuildSuite) TestValidTypes() {
+	var tests = []string{
+		"FIX",
+		"FIXT",
+	}
+
+	for _, test := range tests {
+		s.doc.Type = test
+		dict, err := s.builder.build(s.doc)
+
+		s.Nil(err)
+		s.NotNil(dict)
+		s.Equal(test, dict.FIXType)
+	}
+}
+
+func (s *BuildSuite) TestInvalidTypes() {
+	var tests = []string{
+		"",
+		"invalid",
+	}
+
+	for _, test := range tests {
+		s.doc.Type = test
+		_, err := s.builder.build(s.doc)
+
+		s.NotNil(err)
+	}
+}
+
+func (s *BuildSuite) TestValidMajor() {
+	var tests = []int{
+		4,
+		5,
+	}
+
+	for _, test := range tests {
+		s.doc.Major = strconv.Itoa(test)
+		dict, err := s.builder.build(s.doc)
+
+		s.Nil(err)
+		s.NotNil(dict)
+		s.Equal(test, dict.Major)
+	}
+}
+
+func (s *BuildSuite) TestInvalidMajor() {
+	var tests = []string{
+		"",
+		"notanumber",
+	}
+
+	for _, test := range tests {
+		s.doc.Major = test
+		_, err := s.builder.build(s.doc)
+
+		s.NotNil(err)
+	}
+}
+
+func (s *BuildSuite) TestValidMinor() {
+	var tests = []int{
+		4,
+		5,
+	}
+
+	for _, test := range tests {
+		s.doc.Minor = strconv.Itoa(test)
+		dict, err := s.builder.build(s.doc)
+
+		s.Nil(err)
+		s.NotNil(dict)
+		s.Equal(test, dict.Minor)
+	}
+}
+
+func (s *BuildSuite) TestInvalidMinor() {
+	var tests = []string{
+		"",
+		"notanumber",
+	}
+
+	for _, test := range tests {
+		s.doc.Minor = test
+		_, err := s.builder.build(s.doc)
+
+		s.NotNil(err)
+	}
+}
 
 func TestBuildFieldDef(t *testing.T) {
 	var tests = []struct {
@@ -22,15 +131,9 @@ func TestBuildFieldDef(t *testing.T) {
 
 		b := &builder{doc: nil, dict: dict}
 		f, err := b.buildFieldDef(xmlField)
-		if err != nil {
-			t.Errorf("Unexpected error %v", err)
-		}
 
-		if f.Tag() != 11 {
-			t.Errorf("Unexpected tag %v", f.Tag())
-		}
-		if len(f.childTags()) != 0 {
-			t.Errorf("Got %v children too many", len(f.childTags()))
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, 11, f.Tag())
+		assert.Empty(t, f.childTags())
 	}
 }

--- a/datadictionary/xml.go
+++ b/datadictionary/xml.go
@@ -7,8 +7,8 @@ import (
 //XMLDoc is the unmarshalled root of a FIX Dictionary.
 type XMLDoc struct {
 	Type        string `xml:"type,attr"`
-	Major       int    `xml:"major,attr"`
-	Minor       int    `xml:"minor,attr"`
+	Major       string `xml:"major,attr"`
+	Minor       string `xml:"minor,attr"`
 	ServicePack int    `xml:"servicepack,attr"`
 
 	Header     *XMLComponent   `xml:"header"`

--- a/datadictionary/xml_test.go
+++ b/datadictionary/xml_test.go
@@ -99,8 +99,8 @@ func TestBoilerPlate(t *testing.T) {
 		ExpectedValue interface{}
 	}{
 		{doc.Type, "FIX"},
-		{doc.Major, 4},
-		{doc.Minor, 3},
+		{doc.Major, "4"},
+		{doc.Minor, "3"},
 		{doc.ServicePack, 0},
 	}
 


### PR DESCRIPTION
Adds some defensive coding to verify valid datadictionary input.   The `<fix>` attributes`type`, `major`, and `minor` are required.