### PR TITLE
validate beginstring configuration

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -2,6 +2,7 @@ package quickfix
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -153,6 +154,18 @@ func (s *Settings) AddSession(sessionSettings *SessionSettings) (SessionID, erro
 	s.lazyInit()
 
 	sessionID := sessionIDFromSessionSettings(s.GlobalSettings(), sessionSettings)
+
+	switch sessionID.BeginString {
+	case BeginStringFIX40:
+	case BeginStringFIX41:
+	case BeginStringFIX42:
+	case BeginStringFIX43:
+	case BeginStringFIX44:
+	case BeginStringFIXT11:
+	default:
+		return sessionID, errors.New("BeginString must be FIX.4.0 to FIX.4.4 or FIXT.1.1")
+	}
+
 	if _, dup := s.sessionSettings[sessionID]; dup {
 		return sessionID, fmt.Errorf("duplicate session configured for %v", sessionID)
 	}


### PR DESCRIPTION
`BeginString` must be FIX.4.0 to FIX.4.4 or FIXT.1.1