### PR TITLE
message parse edge cases

### DIFF
--- a/message.go
+++ b/message.go
@@ -141,6 +141,10 @@ func ParseMessageWithDataDictionary(
 		}
 	}
 
+	if fieldCount == 0 {
+		return parseError{OrigError: fmt.Sprintf("No Fields detected in %s", string(rawBytes))}
+	}
+
 	if cap(msg.fields) < fieldCount {
 		msg.fields = make([]TagValue, fieldCount)
 	} else {

--- a/message_test.go
+++ b/message_test.go
@@ -30,6 +30,13 @@ func (s *MessageSuite) SetupTest() {
 	s.msg = NewMessage()
 }
 
+func (s *MessageSuite) TestParseMessageEmpty() {
+	rawMsg := bytes.NewBufferString("")
+
+	err := ParseMessage(s.msg, rawMsg)
+	s.NotNil(err)
+}
+
 func (s *MessageSuite) TestParseMessage() {
 	rawMsg := bytes.NewBufferString("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package quickfix
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"time"
 
@@ -111,10 +112,19 @@ func (p *parser) jumpLength() (int, error) {
 		return 0, err
 	}
 
+	if offset == lengthIndex {
+		return 0, errors.New("No length given")
+	}
+
 	length, err := atoi(p.buffer[lengthIndex:offset])
 	if err != nil {
 		return length, err
 	}
+
+	if length <= 0 {
+		return length, errors.New("Invalid length")
+	}
+
 	return offset + length, nil
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -30,6 +30,20 @@ func (s *ParserSuite) SetupTest() {
 	s.parser = new(parser)
 }
 
+func (s *ParserSuite) TestInvalidNilLength() {
+	stream := "8=\x019=\x01"
+	s.reader = strings.NewReader(stream)
+	_, err := s.ReadMessage()
+	s.NotNil(err)
+}
+
+func (s *ParserSuite) TestOverflowLength() {
+	stream := "8=\x019=9300000000000000000\x01"
+	s.reader = strings.NewReader(stream)
+	_, err := s.ReadMessage()
+	s.NotNil(err)
+}
+
 func (s *ParserSuite) TestJumpLength() {
 	stream := "8=FIXT.1.19=11135=D34=449=TW52=20140511-23:10:3456=ISLD11=ID21=340=154=155=INTC60=20140511-23:10:3410=2348=FIXT.1.19=9535=D34=549=TW52=20140511-23:10:3456=ISLD11=ID21=340=154=155=INTC60=20140511-23:10:3410=198"
 

--- a/tag_value.go
+++ b/tag_value.go
@@ -23,19 +23,19 @@ func (tv *TagValue) init(tag Tag, value []byte) {
 	tv.value = value
 }
 
-func (tv *TagValue) parse(rawFieldBytes []byte) (err error) {
+func (tv *TagValue) parse(rawFieldBytes []byte) error {
 	sepIndex := bytes.IndexByte(rawFieldBytes, '=')
 
-	if sepIndex == -1 {
-		err = fmt.Errorf("tagValue.Parse: No '=' in '%s'", rawFieldBytes)
-		return
+	switch sepIndex {
+	case -1:
+		return fmt.Errorf("tagValue.Parse: No '=' in '%s'", rawFieldBytes)
+	case 0:
+		return fmt.Errorf("tagValue.Parse: No tag in '%s'", rawFieldBytes)
 	}
 
 	parsedTag, err := atoi(rawFieldBytes[:sepIndex])
-
 	if err != nil {
-		err = fmt.Errorf("tagValue.Parse: %s", err.Error())
-		return
+		return fmt.Errorf("tagValue.Parse: %s", err.Error())
 	}
 
 	tv.tag = Tag(parsedTag)
@@ -43,7 +43,7 @@ func (tv *TagValue) parse(rawFieldBytes []byte) (err error) {
 	tv.value = rawFieldBytes[(sepIndex + 1):(n - 1):(n - 1)]
 	tv.bytes = rawFieldBytes[:n:n]
 
-	return
+	return nil
 }
 
 func (tv TagValue) String() string {

--- a/tag_value_test.go
+++ b/tag_value_test.go
@@ -26,14 +26,8 @@ func TestTagValue_parse(t *testing.T) {
 	stringField := "8=FIX.4.0"
 	tv := TagValue{}
 	err := tv.parse([]byte(stringField))
-
-	if err != nil {
-		t.Error("Unexpected error", err)
-	}
-
-	if tv.tag != Tag(8) {
-		t.Error("Unexpected tag", tv.tag)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, Tag(8), tv.tag)
 
 	if !bytes.Equal(tv.bytes, []byte(stringField)) {
 		t.Errorf("Expected %v got %v", stringField, tv.bytes)
@@ -51,6 +45,9 @@ func TestTagValue_parseFail(t *testing.T) {
 	assert.NotNil(t, tv.parse([]byte(stringField)))
 
 	stringField = "tag_not_an_int=uhoh"
+	assert.NotNil(t, tv.parse([]byte(stringField)))
+
+	stringField = "=notag"
 	assert.NotNil(t, tv.parse([]byte(stringField)))
 }
 


### PR DESCRIPTION
instead of panic, correctly handle parsing malformed messages in cases where a message is blank, or tag values have no tags.