### PR TITLE
Fix a data race condition in the memoryStore

### DIFF
--- a/store.go
+++ b/store.go
@@ -35,11 +35,11 @@ type memoryStore struct {
 	messageMap                       map[int][]byte
 }
 
-func (store memoryStore) NextSenderMsgSeqNum() int {
+func (store *memoryStore) NextSenderMsgSeqNum() int {
 	return store.senderMsgSeqNum + 1
 }
 
-func (store memoryStore) NextTargetMsgSeqNum() int {
+func (store *memoryStore) NextTargetMsgSeqNum() int {
 	return store.targetMsgSeqNum + 1
 }
 
@@ -62,7 +62,7 @@ func (store *memoryStore) SetNextTargetMsgSeqNum(nextSeqNum int) error {
 	return nil
 }
 
-func (store memoryStore) CreationTime() time.Time {
+func (store *memoryStore) CreationTime() time.Time {
 	return store.creationTime
 }
 
@@ -93,7 +93,7 @@ func (store *memoryStore) SaveMessage(seqNum int, msg []byte) error {
 	return nil
 }
 
-func (store memoryStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) {
+func (store *memoryStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) {
 	var msgs [][]byte
 	for seqNum := beginSeqNum; seqNum <= endSeqNum; seqNum++ {
 		if m, ok := store.messageMap[seqNum]; ok {
@@ -106,9 +106,9 @@ func (store memoryStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, erro
 type memoryStoreFactory struct{}
 
 func (f memoryStoreFactory) Create(sessionID SessionID) (MessageStore, error) {
-	var m memoryStore
+	m := new(memoryStore)
 	m.Reset()
-	return &m, nil
+	return m, nil
 }
 
 //NewMemoryStoreFactory returns a MessageStoreFactory instance that created in-memory MessageStores


### PR DESCRIPTION
@cbusbey I already got it back again... See the output below:

```
==================
WARNING: DATA RACE
Read at 0x00c42019ea28 by main goroutine:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*memoryStore).NextSenderMsgSeqNum()
      <autogenerated>:1 +0x53
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).prepMessageForSend()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:279 +0x9a
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).queueForSend()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:204 +0xcd
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.SendToTarget()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/registry.go:50 +0xb3
  main.(*Router).sendRequests()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:113 +0x4b1
  main.(*Router).Unsubscribe()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:78 +0x5b
  main.(*Router).Stop()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:63 +0xc7
  main.runMarketDataCommand()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:127 +0x2b5
  main.NewMarketDataCommand.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:62 +0x33
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:750 +0x886
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:831 +0x444
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:784 +0x38
  main.main()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:50 +0x34

Previous write at 0x00c42019ea28 by goroutine 9:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*memoryStore).IncrNextTargetMsgSeqNum()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/store.go:52 +0x64
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.inSession.FixMsgIn()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/in_session.go:44 +0x43d
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*inSession).FixMsgIn()
      <autogenerated>:1 +0x76
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*stateMachine).fixMsgIn()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session_state.go:87 +0x69
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*stateMachine).Incoming()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session_state.go:77 +0x4fe
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).run()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:751 +0x567
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).handleConnection.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:114 +0x38

Goroutine 9 (running) created at:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).handleConnection()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:113 +0xcf
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).Start.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:38 +0xe0
==================
==================
WARNING: DATA RACE
Write at 0x00c42019ea20 by main goroutine:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*memoryStore).IncrNextSenderMsgSeqNum()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/store.go:47 +0x54
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).persist()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:328 +0x75
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).prepMessageForSend()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:316 +0x363
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).queueForSend()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:204 +0xcd
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.SendToTarget()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/registry.go:50 +0xb3
  main.(*Router).sendRequests()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:113 +0x4b1
  main.(*Router).Unsubscribe()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:78 +0x5b
  main.(*Router).Stop()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/router.go:63 +0xc7
  main.runMarketDataCommand()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:127 +0x2b5
  main.NewMarketDataCommand.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:62 +0x33
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:750 +0x886
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:831 +0x444
  github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/spf13/cobra/command.go:784 +0x38
  main.main()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/cmd/marketdata/main.go:50 +0x34

Previous read at 0x00c42019ea20 by goroutine 9:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*memoryStore).NextTargetMsgSeqNum()
      <autogenerated>:1 +0x53
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).checkTargetTooLow()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:540 +0x170
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).verifySelect()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:497 +0x2a9
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).verify()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:472 +0x49
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.inSession.FixMsgIn()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/in_session.go:39 +0x402
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*inSession).FixMsgIn()
      <autogenerated>:1 +0x76
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*stateMachine).fixMsgIn()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session_state.go:87 +0x69
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*stateMachine).Incoming()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session_state.go:77 +0x4fe
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*session).run()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/session.go:751 +0x567
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).handleConnection.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:114 +0x38

Goroutine 9 (running) created at:
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).handleConnection()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:113 +0xcf
  github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix.(*Initiator).Start.func1()
      /Users/svanharmelen/Documents/GoCode/src/github.com/svanharmelen/xtdr/vendor/github.com/quickfixgo/quickfix/initiator.go:38 +0xe0
==================
```