### PR TITLE
added new exported unregister session call

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -50,6 +50,19 @@ func SendToTarget(m Messagable, sessionID SessionID) error {
 	return session.queueForSend(msg)
 }
 
+//UnregisterSession removes a session from the set of known sessions
+func UnregisterSession(sessionID SessionID) error {
+	sessionsLock.Lock()
+	defer sessionsLock.Unlock()
+
+	if _, ok := sessions[sessionID]; ok {
+		delete(sessions, sessionID)
+		return nil
+	}
+
+	return errUnknownSession
+}
+
 func registerSession(s *session) error {
 	sessionsLock.Lock()
 	defer sessionsLock.Unlock()


### PR DESCRIPTION
useful for test cleanup in other packages.  an example, when SessionIDs are tracked in `sessions`:

```go
for _, s := range sessions {
	err := fix.UnregisterSession(s)
	if err != nil {
		log.Printf("could not remove session %s: %s", s.String(), err.Error())
	}
}
```