### PR TITLE
added support for code generation on windows

### DIFF
--- a/cmd/generate-fix/internal/helpers_windows.go
+++ b/cmd/generate-fix/internal/helpers_windows.go
@@ -1,10 +1,10 @@
-// +build !windows
+// +build windows
 
 package internal
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -17,7 +17,8 @@ func getImportPathRoot() string {
 	if err != nil {
 		panic(err)
 	}
-	goSrcPath := path.Join(os.Getenv("GOPATH"), "src")
-	importPathRoot := strings.Replace(pwd, goSrcPath, "", 1)
+	//goSrcPath := `C:\Users\Administrator\go\src\`
+	goSrcPath := filepath.Join(os.Getenv("USERPROFILE"), "Go", "src")
+	importPathRoot := filepath.ToSlash(strings.Replace(pwd, goSrcPath, "", 1))
 	return strings.TrimLeft(importPathRoot, "/")
 }

--- a/cmd/generate-fix/internal/helpers_windows_test.go
+++ b/cmd/generate-fix/internal/helpers_windows_test.go
@@ -1,0 +1,10 @@
+package internal
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetImportPathRoot(t *testing.T) {
+	fmt.Println("this is import :", getImportPathRoot())
+}


### PR DESCRIPTION
Minor changes that permit code generation on windows and uses filepath in place of path. An initial prototype test function has been added but doesn't really do any validation and really needs a cross platform implementation. 