### PR TITLE
Message deep copy

### DIFF
--- a/message.go
+++ b/message.go
@@ -128,8 +128,12 @@ func (m *Message) CopyInto(to *Message) error {
 	to.rawMessage = m.rawMessage
 	to.ReceiveTime = m.ReceiveTime
 	to.bodyBytes = make([]byte, len(m.bodyBytes))
-
-	to.cook()
+	copy(to.bodyBytes, m.bodyBytes)
+	to.fields = make([]TagValue, len(m.fields))
+	for i := range to.fields {
+		to.fields[i].init(m.fields[i].tag, m.fields[i].value)
+		fmt.Println(i)
+	}
 	return nil
 }
 

--- a/message.go
+++ b/message.go
@@ -114,6 +114,25 @@ func NewMessage() *Message {
 	return m
 }
 
+// CopyInto erases the dest messages and copies the curreny message content
+// into it.
+func (m *Message) CopyInto(to *Message) error {
+	to.Header.Clear()
+	to.Body.Clear()
+	to.Trailer.Clear()
+
+	to.Header.FieldMap = cloneFieldMap(m.Header.FieldMap)
+	to.Body.FieldMap = cloneFieldMap(m.Body.FieldMap)
+	to.Trailer.FieldMap = cloneFieldMap(m.Trailer.FieldMap)
+
+	to.rawMessage = m.rawMessage
+	to.ReceiveTime = m.ReceiveTime
+	to.bodyBytes = make([]byte, len(m.bodyBytes))
+
+	to.cook()
+	return nil
+}
+
 //ParseMessage constructs a Message from a byte slice wrapping a FIX message.
 func ParseMessage(msg *Message, rawMessage *bytes.Buffer) (err error) {
 	return ParseMessageWithDataDictionary(msg, rawMessage, nil, nil)
@@ -362,4 +381,15 @@ func (m *Message) cook() {
 	m.Header.SetInt(tagBodyLength, bodyLength)
 	checkSum := (m.Header.total() + m.Body.total() + m.Trailer.total()) % 256
 	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
+}
+
+func cloneFieldMap(f FieldMap) FieldMap {
+	res := FieldMap{}
+	res.tagLookup = make(map[Tag]field)
+	for tag, field := range f.tagLookup {
+		res.tagLookup[tag] = field
+	}
+	res.tags = make([]Tag, len(f.tags))
+	copy(res.tags, f.tags)
+	return res
 }

--- a/message_test.go
+++ b/message_test.go
@@ -166,3 +166,16 @@ func (s *MessageSuite) TestReverseRouteFIX40() {
 
 	s.False(builder.Header.Has(tagOnBehalfOfLocationID), "onbehalfof location id not supported in fix40")
 }
+
+func (s *MessageSuite) TestCopyIntoMessage() {
+	//onbehalfof/deliverto location id not supported in fix 4.0
+	s.Nil(ParseMessage(s.msg, bytes.NewBufferString("8=FIX.4.09=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
+
+	dest := NewMessage()
+	s.msg.CopyInto(dest)
+	seqNum, _ := dest.Header.GetInt(tagMsgSeqNum)
+	s.Equal(2, seqNum)
+
+	handInst, _ := dest.Body.GetInt(21)
+	s.Equal(3, handInst)
+}


### PR DESCRIPTION
This is a followup to https://github.com/quickfixgo/quickfix/issues/338 
I added a  `CopyInto` method to message implementing the deep copy of the message is being called to.