### PR TITLE
Removed debug print

### DIFF
--- a/message.go
+++ b/message.go
@@ -132,7 +132,6 @@ func (m *Message) CopyInto(to *Message) error {
 	to.fields = make([]TagValue, len(m.fields))
 	for i := range to.fields {
 		to.fields[i].init(m.fields[i].tag, m.fields[i].value)
-		fmt.Println(i)
 	}
 	return nil
 }


### PR DESCRIPTION
Sorry, while re-looking at what I did with https://github.com/quickfixgo/quickfix/pull/341 I spotted a debug print I left.
This removes it.