### PR TITLE
Add top of tag stack to error on repeating groups

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -22,6 +22,7 @@ const (
 	SocketInsecureSkipVerify     string = "SocketInsecureSkipVerify"
 	SocketMinimumTLSVersion      string = "SocketMinimumTLSVersion"
 	SocketTimeout                string = "SocketTimeout"
+	SocketUseSSL                 string = "SocketUseSSL"
 	DefaultApplVerID             string = "DefaultApplVerID"
 	StartTime                    string = "StartTime"
 	EndTime                      string = "EndTime"

--- a/config/doc.go
+++ b/config/doc.go
@@ -284,6 +284,10 @@ SocketMinimumTLSVersion
 
 Specify the Minimum TLS version to use when creating a secure connection. The valid choices are SSL30, TLS10, TLS11, TLS12. Defaults to TLS12.
 
+SocketUseSSL
+
+Use SSL for initiators even if client certificates are not present. If set to N or omitted, TLS will not be used if SocketPrivateKeyFile or SocketCertificateFile are not supplied.
+
 PersistMessages
 
 If set to N, no messages will be persisted. This will force QuickFIX/Go to always send GapFills instead of resending messages. Use this if you know you never want to resend a message. Useful for market data streams.  Valid Values:

--- a/repeating_group.go
+++ b/repeating_group.go
@@ -203,7 +203,7 @@ func (f *RepeatingGroup) Read(tv []TagValue) ([]TagValue, error) {
 	}
 
 	if len(f.groups) != expectedGroupSize {
-		return tv, repeatingGroupFieldsOutOfOrder(f.tag, fmt.Sprintf("group %v: template is wrong or delimiter %v not found: expected %v groups, but found %v", f.tag, f.delimiter(), expectedGroupSize, len(f.groups)))
+		return tv, repeatingGroupFieldsOutOfOrder(f.tag, fmt.Sprintf("group %v: template is wrong (%v found but not in group) or delimiter %v not found: expected %v groups, but found %v.", f.tag, tv[0], f.delimiter(), expectedGroupSize, len(f.groups)))
 	}
 
 	return tv, err

--- a/tls.go
+++ b/tls.go
@@ -10,6 +10,14 @@ import (
 )
 
 func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error) {
+	allowSkipClientCerts := false
+	if settings.HasSetting(config.SocketUseSSL) {
+		allowSkipClientCerts, err = settings.BoolSetting(config.SocketUseSSL)
+		if err != nil {
+			return
+		}
+	}
+
 	insecureSkipVerify := false
 	if settings.HasSetting(config.SocketInsecureSkipVerify) {
 		insecureSkipVerify, err = settings.BoolSetting(config.SocketInsecureSkipVerify)
@@ -19,9 +27,9 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 	}
 
 	if !settings.HasSetting(config.SocketPrivateKeyFile) && !settings.HasSetting(config.SocketCertificateFile) {
-		if insecureSkipVerify {
+		if allowSkipClientCerts {
 			tlsConfig = defaultTLSConfig()
-			tlsConfig.InsecureSkipVerify = true
+			tlsConfig.InsecureSkipVerify = insecureSkipVerify
 		}
 		return
 	}


### PR DESCRIPTION
Currently, debugging an incorrect repeating group template which is missing a tag is difficult because the required information (i.e. the tag which caused quickfix to think it had reached the end of the group and therefore had an erroneous group count) is not surfaced anywhere.

Adding the top tag of the stack to the error message makes debugging these issues much simpler.

I'm not sure if it's safe to always assume tv[0] exists - if not, some additional logic will be required.