### PR TITLE
Add SocketUseSSL parameter to allow SSL/TLS without client certs

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -22,6 +22,7 @@ const (
 	SocketInsecureSkipVerify     string = "SocketInsecureSkipVerify"
 	SocketMinimumTLSVersion      string = "SocketMinimumTLSVersion"
 	SocketTimeout                string = "SocketTimeout"
+	SocketUseSSL                 string = "SocketUseSSL"
 	DefaultApplVerID             string = "DefaultApplVerID"
 	StartTime                    string = "StartTime"
 	EndTime                      string = "EndTime"

--- a/config/doc.go
+++ b/config/doc.go
@@ -284,6 +284,10 @@ SocketMinimumTLSVersion
 
 Specify the Minimum TLS version to use when creating a secure connection. The valid choices are SSL30, TLS10, TLS11, TLS12. Defaults to TLS12.
 
+SocketUseSSL
+
+Use SSL for initiators even if client certificates are not present. If set to N or omitted, TLS will not be used if SocketPrivateKeyFile or SocketCertificateFile are not supplied.
+
 PersistMessages
 
 If set to N, no messages will be persisted. This will force QuickFIX/Go to always send GapFills instead of resending messages. Use this if you know you never want to resend a message. Useful for market data streams.  Valid Values:

--- a/tls.go
+++ b/tls.go
@@ -10,6 +10,14 @@ import (
 )
 
 func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error) {
+	allowSkipClientCerts := false
+	if settings.HasSetting(config.SocketUseSSL) {
+		allowSkipClientCerts, err = settings.BoolSetting(config.SocketUseSSL)
+		if err != nil {
+			return
+		}
+	}
+
 	insecureSkipVerify := false
 	if settings.HasSetting(config.SocketInsecureSkipVerify) {
 		insecureSkipVerify, err = settings.BoolSetting(config.SocketInsecureSkipVerify)
@@ -19,9 +27,9 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 	}
 
 	if !settings.HasSetting(config.SocketPrivateKeyFile) && !settings.HasSetting(config.SocketCertificateFile) {
-		if insecureSkipVerify {
+		if allowSkipClientCerts {
 			tlsConfig = defaultTLSConfig()
-			tlsConfig.InsecureSkipVerify = true
+			tlsConfig.InsecureSkipVerify = insecureSkipVerify
 		}
 		return
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -90,6 +90,14 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 func (s *TLSTestSuite) TestInsecureSkipVerify() {
 	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
 
+	_, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.NotNil(err)
+}
+
+func (s *TLSTestSuite) TestInsecureSkipVerifyWithUseSSL() {
+	s.settings.GlobalSettings().Set(config.SocketUseSSL, "Y")
+	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
+
 	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
 	s.Nil(err)
 	s.NotNil(tlsConfig)

--- a/tls_test.go
+++ b/tls_test.go
@@ -90,8 +90,9 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 func (s *TLSTestSuite) TestInsecureSkipVerify() {
 	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
 
-	_, err := loadTLSConfig(s.settings.GlobalSettings())
-	s.NotNil(err)
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.Nil(tlsConfig)
 }
 
 func (s *TLSTestSuite) TestInsecureSkipVerifyWithUseSSL() {


### PR DESCRIPTION
I realise this has been covered in #311 but I'm providing a pull request, and there is a potential security issue/footgun with the current behaviour.

In my experience, at least two major exchanges (ICE and CME) do not use client certificate authentication for their FIX trade capture endpoints, and therefore quickfixgo cannot be used with them currently. Instead, the server provides a TLS certificate and login is via username/password field in the login message.

There is a very insecure workaround right now - setting SocketInsecureSkipVerify=Y has the side effect of allowing a TLS connection even without client certificates. However, it also does not verify the received certificates which obviously a presents a large security risk (especially given that both ICE and CME provide valid, signed certificates for their respective endpoint addresses). The security issue I see is that developers who need this functionality might just be setting SocketInsecureSkipVerify, rather than going through the friction of forking/pull requests etc and thereby making themselves vulnerable to MITM/DNS takeovers which would allow exchange credential theft.

With that in mind, I have added a "SocketUseSSL" parameter which will make quickfixgo establish a TLS connection even if client certificates are not present whilst allowing server certificate verification. Current behaviour also means that SocketTimeout & SocketMinimumTLSVersion will be ignored in this mode, in line with the existing behaviour when SocketInsecureSkipVerify is used. I'm happy to refactor things more but given that this is crypto code I'd rather get some feedback/thoughts first.