### PR TITLE
Fix `Message.CopyInto()` to fully deep copy and remove the error return value #338

### DIFF
--- a/field_map.go
+++ b/field_map.go
@@ -199,6 +199,19 @@ func (m *FieldMap) Clear() {
 	}
 }
 
+//CopyInto overwrites the given FieldMap with this one
+func (m *FieldMap) CopyInto(to *FieldMap) {
+	to.tagLookup = make(map[Tag]field)
+	for tag, f := range m.tagLookup {
+		clone := make(field, 1)
+		clone[0] = f[0]
+		to.tagLookup[tag] = clone
+	}
+	to.tags = make([]Tag, len(m.tags))
+	copy(to.tags, m.tags)
+	to.compare = m.compare
+}
+
 func (m *FieldMap) add(f field) {
 	t := fieldTag(f)
 	if _, ok := m.tagLookup[t]; !ok {

--- a/field_map_test.go
+++ b/field_map_test.go
@@ -125,3 +125,53 @@ func TestFieldMap_BoolTypedSetAndGet(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "N", s)
 }
+
+func TestFieldMap_CopyInto(t *testing.T) {
+	var fMapA FieldMap
+	fMapA.initWithOrdering(headerFieldOrdering)
+	fMapA.SetString(9, "length")
+	fMapA.SetString(8, "begin")
+	fMapA.SetString(35, "msgtype")
+	fMapA.SetString(1, "a")
+	assert.Equal(t, []Tag{8, 9, 35, 1}, fMapA.sortedTags())
+
+	var fMapB FieldMap
+	fMapB.init()
+	fMapB.SetString(1, "A")
+	fMapB.SetString(3, "C")
+	fMapB.SetString(4, "D")
+	assert.Equal(t, fMapB.sortedTags(), []Tag{1, 3, 4})
+
+	fMapA.CopyInto(&fMapB)
+
+	assert.Equal(t, []Tag{8, 9, 35, 1}, fMapB.sortedTags())
+
+	// new fields
+	s, err := fMapB.GetString(35)
+	assert.Nil(t, err)
+	assert.Equal(t, "msgtype", s)
+
+	// existing fields overwritten
+	s, err = fMapB.GetString(1)
+	assert.Nil(t, err)
+	assert.Equal(t, "a", s)
+
+	// old fields cleared
+	s, err = fMapB.GetString(3)
+	assert.NotNil(t, err)
+
+	// check that ordering is overwritten
+	fMapB.SetString(2, "B")
+	assert.Equal(t, []Tag{8, 9, 35, 1, 2}, fMapB.sortedTags())
+
+	// updating the existing map doesn't affect the new
+	fMapA.init()
+	fMapA.SetString(1, "AA")
+	s, err = fMapB.GetString(1)
+	assert.Nil(t, err)
+	assert.Equal(t, "a", s)
+	fMapA.Clear()
+	s, err = fMapB.GetString(1)
+	assert.Nil(t, err)
+	assert.Equal(t, "a", s)
+}

--- a/message_test.go
+++ b/message_test.go
@@ -169,20 +169,39 @@ func (s *MessageSuite) TestReverseRouteFIX40() {
 }
 
 func (s *MessageSuite) TestCopyIntoMessage() {
-	s.Nil(ParseMessage(s.msg, bytes.NewBufferString("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
+	msgString := "8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123"
+	msgBuf := bytes.NewBufferString(msgString)
+	s.Nil(ParseMessage(s.msg, msgBuf))
 
 	dest := NewMessage()
 	s.msg.CopyInto(dest)
+
 	checkFieldInt(s, dest.Header.FieldMap, int(tagMsgSeqNum), 2)
 	checkFieldInt(s, dest.Body.FieldMap, 21, 3)
 	checkFieldString(s, dest.Body.FieldMap, 11, "ID")
 	s.Equal(len(dest.bodyBytes), len(s.msg.bodyBytes))
+
+	// copying decouples the message from its input buffer, so the raw message will be re-rendered
+	renderedString := "8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP115=JCD116=CS128=MG129=CB142=JV143=RY144=BB145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=033"
+	s.Equal(dest.String(), renderedString)
 
 	s.True(reflect.DeepEqual(s.msg.bodyBytes, dest.bodyBytes))
 	s.True(s.msg.IsMsgTypeOf("D"))
 	s.Equal(s.msg.ReceiveTime, dest.ReceiveTime)
 
 	s.True(reflect.DeepEqual(s.msg.fields, dest.fields))
+
+	// update the source message to validate the copy is truly deep
+	newMsgString := "8=FIX.4.49=4935=A52=20140615-19:49:56553=my_user554=secret10=072"
+	s.Nil(ParseMessage(s.msg, bytes.NewBufferString(newMsgString)))
+	s.True(s.msg.IsMsgTypeOf("A"))
+	s.Equal(s.msg.String(), newMsgString)
+
+	// clear the source buffer also
+	msgBuf.Reset()
+
+	s.True(dest.IsMsgTypeOf("D"))
+	s.Equal(dest.String(), renderedString)
 }
 
 func checkFieldInt(s *MessageSuite, fields FieldMap, tag, expected int) {


### PR DESCRIPTION
It's unclear if we should copy `Message.rawMessage` here. I chose not to in case the original buffer is changed. I think the point of `Message.CopyInto()` is to decouple the new instance from the old, and shouldn't be used in high-performance scenarios anyway.

I removed the error return value because I don't understand when you'd expect an error. We could add it back for API compatibility. I don't think the name `CopyInto()` is idiomatic Go, but I don't see any obvious examples for naming something similar.