### PR TITLE
Support for Username(tag 553) and Password(tag 554)

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -52,4 +52,7 @@ const (
 	MaxLatency                   string = "MaxLatency"
 	PersistMessages              string = "PersistMessages"
 	RejectInvalidMessage         string = "RejectInvalidMessage"
+	Username					 string = "Username"
+	Password					 string = "Password"
+	PartyID					 	 string = "PartyID"
 )

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -54,5 +54,4 @@ const (
 	RejectInvalidMessage         string = "RejectInvalidMessage"
 	Username					 string = "Username"
 	Password					 string = "Password"
-	PartyID					 	 string = "PartyID"
 )

--- a/session.go
+++ b/session.go
@@ -147,9 +147,6 @@ func (s *session) sendLogonInReplyTo(resetStore, setResetSeqNum bool, inReplyTo 
 		logon.Header.SetField(tagUsername, FIXString(s.sessionID.Username))
 		logon.Header.SetField(tagPassword, FIXString(s.sessionID.Password))
 	}
-	if "" != s.sessionID.PartyID {
-		logon.Header.SetField(tagPartyID, FIXString(s.sessionID.PartyID))
-	}
 	logon.Body.SetField(tagEncryptMethod, FIXString("0"))
 	logon.Body.SetField(tagHeartBtInt, FIXInt(s.HeartBtInt.Seconds()))
 

--- a/session.go
+++ b/session.go
@@ -143,6 +143,13 @@ func (s *session) sendLogonInReplyTo(resetStore, setResetSeqNum bool, inReplyTo 
 	logon.Header.SetField(tagBeginString, FIXString(s.sessionID.BeginString))
 	logon.Header.SetField(tagTargetCompID, FIXString(s.sessionID.TargetCompID))
 	logon.Header.SetField(tagSenderCompID, FIXString(s.sessionID.SenderCompID))
+	if "" != s.sessionID.Username {
+		logon.Header.SetField(tagUsername, FIXString(s.sessionID.Username))
+		logon.Header.SetField(tagPassword, FIXString(s.sessionID.Password))
+	}
+	if "" != s.sessionID.PartyID {
+		logon.Header.SetField(tagPartyID, FIXString(s.sessionID.PartyID))
+	}
 	logon.Body.SetField(tagEncryptMethod, FIXString("0"))
 	logon.Body.SetField(tagHeartBtInt, FIXInt(s.HeartBtInt.Seconds()))
 

--- a/session_id.go
+++ b/session_id.go
@@ -4,7 +4,7 @@ import "bytes"
 
 // SessionID is a unique identifer of a Session
 type SessionID struct {
-	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier string
+	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier, Username, Password, PartyID string
 }
 
 //IsFIXT returns true if the SessionID has a FIXT BeginString

--- a/session_id.go
+++ b/session_id.go
@@ -4,7 +4,7 @@ import "bytes"
 
 // SessionID is a unique identifer of a Session
 type SessionID struct {
-	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier, Username, Password, PartyID string
+	BeginString, TargetCompID, TargetSubID, TargetLocationID, SenderCompID, SenderSubID, SenderLocationID, Qualifier, Username, Password string
 }
 
 //IsFIXT returns true if the SessionID has a FIXT BeginString

--- a/settings.go
+++ b/settings.go
@@ -70,6 +70,18 @@ func sessionIDFromSessionSettings(globalSettings *SessionSettings, sessionSettin
 		if settings.HasSetting(config.SessionQualifier) {
 			sessionID.Qualifier, _ = settings.Setting(config.SessionQualifier)
 		}
+
+		if settings.HasSetting(config.Username) {
+			sessionID.Username, _ = settings.Setting(config.Username)
+		}
+
+		if settings.HasSetting(config.Password) {
+			sessionID.Password, _ = settings.Setting(config.Password)
+		}
+
+		if settings.HasSetting(config.PartyID) {
+			sessionID.PartyID, _ = settings.Setting(config.PartyID)
+		}
 	}
 
 	return sessionID

--- a/settings.go
+++ b/settings.go
@@ -78,10 +78,6 @@ func sessionIDFromSessionSettings(globalSettings *SessionSettings, sessionSettin
 		if settings.HasSetting(config.Password) {
 			sessionID.Password, _ = settings.Setting(config.Password)
 		}
-
-		if settings.HasSetting(config.PartyID) {
-			sessionID.PartyID, _ = settings.Setting(config.PartyID)
-		}
 	}
 
 	return sessionID

--- a/tag.go
+++ b/tag.go
@@ -40,7 +40,6 @@ const (
 	tagHopRefID               Tag = 630
 	tagUsername				  Tag = 553
 	tagPassword				  Tag = 554
-	tagPartyID				  Tag = 453
 
 	tagHeartBtInt           Tag = 108
 	tagBusinessRejectReason Tag = 380

--- a/tag.go
+++ b/tag.go
@@ -38,6 +38,9 @@ const (
 	tagHopCompID              Tag = 628
 	tagHopSendingTime         Tag = 629
 	tagHopRefID               Tag = 630
+	tagUsername				  Tag = 553
+	tagPassword				  Tag = 554
+	tagPartyID				  Tag = 453
 
 	tagHeartBtInt           Tag = 108
 	tagBusinessRejectReason Tag = 380


### PR DESCRIPTION
Support for Username (tag 553), Password (tag 554), and PartyID (tag 453) in Logon message (from sessionID struct). If these fields have empty values, then they are not sent in the Logon message.