### PR TITLE
Add top of tag stack to error on repeating groups

### DIFF
--- a/repeating_group.go
+++ b/repeating_group.go
@@ -203,7 +203,7 @@ func (f *RepeatingGroup) Read(tv []TagValue) ([]TagValue, error) {
 	}
 
 	if len(f.groups) != expectedGroupSize {
-		return tv, repeatingGroupFieldsOutOfOrder(f.tag, fmt.Sprintf("group %v: template is wrong or delimiter %v not found: expected %v groups, but found %v", f.tag, f.delimiter(), expectedGroupSize, len(f.groups)))
+		return tv, repeatingGroupFieldsOutOfOrder(f.tag, fmt.Sprintf("group %v: template is wrong (%v found but not in group) or delimiter %v not found: expected %v groups, but found %v.", f.tag, tv[0], f.delimiter(), expectedGroupSize, len(f.groups)))
 	}
 
 	return tv, err


### PR DESCRIPTION
Sorry about the last one, forgot to do the pull against a branch.

Currently, debugging an incorrect repeating group template which is missing a tag is difficult because the required information (i.e. the tag which caused quickfix to think it had reached the end of the group) is not surfaced anywhere.

Adding the top tag of the stack to the error message makes debugging these issues much simpler. If tv[0] can be null, this might be problematic and a different solution will be needed!