### PR TITLE
Tls server name config

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -20,6 +20,7 @@ const (
 	SocketCertificateFile        string = "SocketCertificateFile"
 	SocketCAFile                 string = "SocketCAFile"
 	SocketInsecureSkipVerify     string = "SocketInsecureSkipVerify"
+	SocketServerName             string = "SocketServerName"
 	SocketMinimumTLSVersion      string = "SocketMinimumTLSVersion"
 	SocketTimeout                string = "SocketTimeout"
 	SocketUseSSL                 string = "SocketUseSSL"

--- a/config/doc.go
+++ b/config/doc.go
@@ -280,6 +280,10 @@ SocketCAFile
 
 Optional root CA to use for secure TLS connections. For acceptors, client certificates will be verified against this CA.  For initiators, clients will use the CA to verify the server certificate. If not configurated, initiators will verify the server certificate using the host's root CA set.
 
+SocketServerName
+
+The expected server name on a returned certificate, unless SocketInsecureSkipVerify is true. This is for the TLS Server Name Indication extension. Initiator only.
+
 SocketMinimumTLSVersion
 
 Specify the Minimum TLS version to use when creating a secure connection. The valid choices are SSL30, TLS10, TLS11, TLS12. Defaults to TLS12.

--- a/initiator.go
+++ b/initiator.go
@@ -154,7 +154,11 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			// Unless InsecureSkipVerify is true, server name config is required for TLS
 			// to verify the received certificate
 			if !tlsConfig.InsecureSkipVerify && len(tlsConfig.ServerName) == 0 {
-				tlsConfig.ServerName = address
+				serverName := address
+				if c := strings.LastIndex(serverName, ":"); c > 0 {
+					serverName = serverName[:c]
+				}
+				tlsConfig.ServerName = serverName
 			}
 			tlsConn := tls.Client(netConn, tlsConfig)
 			if err = tlsConn.Handshake(); err != nil {

--- a/initiator.go
+++ b/initiator.go
@@ -3,6 +3,7 @@ package quickfix
 import (
 	"bufio"
 	"crypto/tls"
+	"strings"
 	"sync"
 	"time"
 

--- a/initiator.go
+++ b/initiator.go
@@ -151,6 +151,11 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			session.log.OnEventf("Failed to connect: %v", err)
 			goto reconnect
 		} else if tlsConfig != nil {
+			// Unless InsecureSkipVerify is true, server name config is required for TLS
+			// to verify the received certificate
+			if !tlsConfig.InsecureSkipVerify && len(tlsConfig.ServerName) == 0 {
+				tlsConfig.ServerName = address
+			}
 			tlsConn := tls.Client(netConn, tlsConfig)
 			if err = tlsConn.Handshake(); err != nil {
 				session.log.OnEventf("Failed handshake: %v", err)

--- a/tls.go
+++ b/tls.go
@@ -18,6 +18,14 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 		}
 	}
 
+	var serverName string
+	if settings.HasSetting(config.SocketServerName) {
+		serverName, err = settings.Setting(config.SocketServerName)
+		if err != nil {
+			return
+		}
+	}
+
 	insecureSkipVerify := false
 	if settings.HasSetting(config.SocketInsecureSkipVerify) {
 		insecureSkipVerify, err = settings.BoolSetting(config.SocketInsecureSkipVerify)
@@ -29,6 +37,7 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 	if !settings.HasSetting(config.SocketPrivateKeyFile) && !settings.HasSetting(config.SocketCertificateFile) {
 		if allowSkipClientCerts {
 			tlsConfig = defaultTLSConfig()
+			tlsConfig.ServerName = serverName
 			tlsConfig.InsecureSkipVerify = insecureSkipVerify
 		}
 		return
@@ -46,6 +55,7 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 
 	tlsConfig = defaultTLSConfig()
 	tlsConfig.Certificates = make([]tls.Certificate, 1)
+	tlsConfig.ServerName = serverName
 	tlsConfig.InsecureSkipVerify = insecureSkipVerify
 
 	minVersion := "TLS12"

--- a/tls_test.go
+++ b/tls_test.go
@@ -87,6 +87,27 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 	s.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 }
 
+func (s *TLSTestSuite) TestServerNameUseSSL() {
+	s.settings.GlobalSettings().Set(config.SocketUseSSL, "Y")
+	s.settings.GlobalSettings().Set(config.SocketServerName, "DummyServerNameUseSSL")
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+	s.Equal("DummyServerNameUseSSL", tlsConfig.ServerName)
+}
+
+func (s *TLSTestSuite) TestServerNameWithCerts() {
+	s.settings.GlobalSettings().Set(config.SocketPrivateKeyFile, s.PrivateKeyFile)
+	s.settings.GlobalSettings().Set(config.SocketCertificateFile, s.CertificateFile)
+	s.settings.GlobalSettings().Set(config.SocketServerName, "DummyServerNameWithCerts")
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+	s.Equal("DummyServerNameWithCerts", tlsConfig.ServerName)
+}
+
 func (s *TLSTestSuite) TestInsecureSkipVerify() {
 	s.settings.GlobalSettings().Set(config.SocketInsecureSkipVerify, "Y")
 


### PR DESCRIPTION
Fixes #384:
* Support TLS SNI by passing in ServerName configuration
* If 
 -- InsecureSkipVerify is false 
 -- ServerName not configured
then copy the host part of the connection address as the ServerName. This essentially restores the behavior before https://github.com/quickfixgo/quickfix/commit/ce2275bf2c97f679d58b639e7b90d8b3e3e34b8b

Tests done:
* Unit tests - passing
* Manual test with the test code in #384 - passing