### PR TITLE
Adds LogoutTimeout and LogonTimeout as config parameters

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -42,6 +42,7 @@ const (
 	ResetOnLogout                string = "ResetOnLogout"
 	ResetOnDisconnect            string = "ResetOnDisconnect"
 	ReconnectInterval            string = "ReconnectInterval"
+	LogoutTimeout                string = "LogoutTimeout"
 	HeartBtInt                   string = "HeartBtInt"
 	FileLogPath                  string = "FileLogPath"
 	FileStorePath                string = "FileStorePath"

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -43,6 +43,7 @@ const (
 	ResetOnDisconnect            string = "ResetOnDisconnect"
 	ReconnectInterval            string = "ReconnectInterval"
 	LogoutTimeout                string = "LogoutTimeout"
+	LogonTimeout                 string = "LogonTimeout"
 	HeartBtInt                   string = "HeartBtInt"
 	FileLogPath                  string = "FileLogPath"
 	FileStorePath                string = "FileStorePath"

--- a/config/doc.go
+++ b/config/doc.go
@@ -230,6 +230,12 @@ Time between reconnection attempts in seconds. Only used for initiators.    Valu
 
 Defaults to 30
 
+LogoutTimeout
+
+Session setting for logout timeout in seconds. Only used for initiators. Value must be positive integer.
+
+Defaults to 2
+
 HeartBtInt
 
 Heartbeat interval in seconds. Only used for initiators.	Value must be positive integer.

--- a/config/doc.go
+++ b/config/doc.go
@@ -236,6 +236,12 @@ Session setting for logout timeout in seconds. Only used for initiators. Value m
 
 Defaults to 2
 
+LogonTimeout
+
+Session setting for logon timeout in seconds. Only used for initiators. Value must be positive integer.
+
+Defaults to 10
+
 HeartBtInt
 
 Heartbeat interval in seconds. Only used for initiators.	Value must be positive integer.

--- a/internal/session_settings.go
+++ b/internal/session_settings.go
@@ -22,5 +22,6 @@ type SessionSettings struct {
 
 	//specific to initiators
 	ReconnectInterval    time.Duration
+	LogoutTimeout        time.Duration
 	SocketConnectAddress []string
 }

--- a/internal/session_settings.go
+++ b/internal/session_settings.go
@@ -23,5 +23,6 @@ type SessionSettings struct {
 	//specific to initiators
 	ReconnectInterval    time.Duration
 	LogoutTimeout        time.Duration
+	LogonTimeout         time.Duration
 	SocketConnectAddress []string
 }

--- a/session.go
+++ b/session.go
@@ -465,8 +465,7 @@ func (s *session) initiateLogoutInReplyTo(reason string, inReplyTo *Message) (er
 		return
 	}
 	s.log.OnEvent("Inititated logout request")
-	time.AfterFunc(time.Duration(2)*time.Second, func() { s.sessionEvent <- internal.LogoutTimeout })
-
+	time.AfterFunc(s.LogoutTimeout, func() { s.sessionEvent <- internal.LogoutTimeout })
 	return
 }
 

--- a/session_factory.go
+++ b/session_factory.go
@@ -346,6 +346,21 @@ func (f sessionFactory) buildInitiatorSettings(session *session, settings *Sessi
 		session.LogoutTimeout = time.Duration(timeout) * time.Second
 	}
 
+	session.LogonTimeout = 10 * time.Second
+	if settings.HasSetting(config.LogonTimeout) {
+
+		timeout, err := settings.IntSetting(config.LogonTimeout)
+		if err != nil {
+			return err
+		}
+
+		if timeout <= 0 {
+			return errors.New("LogonTimeout must be greater than zero")
+		}
+
+		session.LogonTimeout = time.Duration(timeout) * time.Second
+	}
+
 	return f.configureSocketConnectAddress(session, settings)
 }
 

--- a/session_factory.go
+++ b/session_factory.go
@@ -331,6 +331,21 @@ func (f sessionFactory) buildInitiatorSettings(session *session, settings *Sessi
 		session.ReconnectInterval = time.Duration(interval) * time.Second
 	}
 
+	session.LogoutTimeout = 2 * time.Second
+	if settings.HasSetting(config.LogoutTimeout) {
+
+		timeout, err := settings.IntSetting(config.LogoutTimeout)
+		if err != nil {
+			return err
+		}
+
+		if timeout <= 0 {
+			return errors.New("LogoutTimeout must be greater than zero")
+		}
+
+		session.LogoutTimeout = time.Duration(timeout) * time.Second
+	}
+
 	return f.configureSocketConnectAddress(session, settings)
 }
 

--- a/session_factory_test.go
+++ b/session_factory_test.go
@@ -353,6 +353,7 @@ func (s *SessionFactorySuite) TestNewSessionBuildInitiators() {
 	s.True(session.InitiateLogon)
 	s.Equal(34*time.Second, session.HeartBtInt)
 	s.Equal(30*time.Second, session.ReconnectInterval)
+	s.Equal(2*time.Second, session.LogoutTimeout)
 	s.Equal("127.0.0.1:5000", session.SocketConnectAddress[0])
 }
 
@@ -397,6 +398,30 @@ func (s *SessionFactorySuite) TestNewSessionBuildInitiatorsValidReconnectInterva
 	s.SessionSettings.Set(config.ReconnectInterval, "-20")
 	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
 	s.NotNil(err, "ReconnectInterval must be greater than zero")
+}
+
+func (s *SessionFactorySuite) TestNewSessionBuildInitiatorsValidLogoutTimeout() {
+	s.sessionFactory.BuildInitiators = true
+	s.SessionSettings.Set(config.HeartBtInt, "34")
+	s.SessionSettings.Set(config.SocketConnectHost, "127.0.0.1")
+	s.SessionSettings.Set(config.SocketConnectPort, "3000")
+
+	s.SessionSettings.Set(config.LogoutTimeout, "45")
+	session, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.Nil(err)
+	s.Equal(45*time.Second, session.LogoutTimeout)
+
+	s.SessionSettings.Set(config.LogoutTimeout, "not a number")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogoutTimeout must be a number")
+
+	s.SessionSettings.Set(config.LogoutTimeout, "0")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogoutTimeout must be greater than zero")
+
+	s.SessionSettings.Set(config.LogoutTimeout, "-20")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogoutTimeout must be greater than zero")
 }
 
 func (s *SessionFactorySuite) TestConfigureSocketConnectAddress() {

--- a/session_factory_test.go
+++ b/session_factory_test.go
@@ -353,6 +353,7 @@ func (s *SessionFactorySuite) TestNewSessionBuildInitiators() {
 	s.True(session.InitiateLogon)
 	s.Equal(34*time.Second, session.HeartBtInt)
 	s.Equal(30*time.Second, session.ReconnectInterval)
+	s.Equal(10*time.Second, session.LogonTimeout)
 	s.Equal(2*time.Second, session.LogoutTimeout)
 	s.Equal("127.0.0.1:5000", session.SocketConnectAddress[0])
 }
@@ -422,6 +423,30 @@ func (s *SessionFactorySuite) TestNewSessionBuildInitiatorsValidLogoutTimeout() 
 	s.SessionSettings.Set(config.LogoutTimeout, "-20")
 	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
 	s.NotNil(err, "LogoutTimeout must be greater than zero")
+}
+
+func (s *SessionFactorySuite) TestNewSessionBuildInitiatorsValidLogonTimeout() {
+	s.sessionFactory.BuildInitiators = true
+	s.SessionSettings.Set(config.HeartBtInt, "34")
+	s.SessionSettings.Set(config.SocketConnectHost, "127.0.0.1")
+	s.SessionSettings.Set(config.SocketConnectPort, "3000")
+
+	s.SessionSettings.Set(config.LogonTimeout, "45")
+	session, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.Nil(err)
+	s.Equal(45*time.Second, session.LogonTimeout)
+
+	s.SessionSettings.Set(config.LogonTimeout, "not a number")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogonTimeout must be a number")
+
+	s.SessionSettings.Set(config.LogonTimeout, "0")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogonTimeout must be greater than zero")
+
+	s.SessionSettings.Set(config.LogonTimeout, "-20")
+	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err, "LogonTimeout must be greater than zero")
 }
 
 func (s *SessionFactorySuite) TestConfigureSocketConnectAddress() {


### PR DESCRIPTION
Resolves
*  https://github.com/quickfixgo/quickfix/issues/296 and exposes a logout timeout parameter as a config parameter. Defaults to 2 seconds.

* https://github.com/quickfixgo/quickfix/issues/295 and exposes a logon timeout parameter as a config parameter. Defaults to 10 seconds.

Note
* There might be some room for improvement with unit tests / acceptance tests in this area.. 
