### PR TITLE
feat: Acceptor addr listener accessor

### DIFF
--- a/acceptor.go
+++ b/acceptor.go
@@ -98,7 +98,7 @@ func (a *Acceptor) Stop() {
 	a.sessionGroup.Wait()
 }
 
-// GetListenerAddr returns the net.Addr from the listener of the Acceptor
+//GetListenerAddr returns the net.Addr from the listener of the Acceptor
 func (a *Acceptor) GetListenerAddr() net.Addr {
 	return a.listener.Addr()
 }

--- a/acceptor.go
+++ b/acceptor.go
@@ -98,6 +98,11 @@ func (a *Acceptor) Stop() {
 	a.sessionGroup.Wait()
 }
 
+// GetListenerAddr returns the net.Addr from the listener of the Acceptor
+func (a *Acceptor) GetListenerAddr() net.Addr {
+	return a.listener.Addr()
+}
+
 //NewAcceptor creates and initializes a new Acceptor.
 func NewAcceptor(app Application, storeFactory MessageStoreFactory, settings *Settings, logFactory LogFactory) (a *Acceptor, err error) {
 	a = &Acceptor{


### PR DESCRIPTION
As per https://github.com/quickfixgo/quickfix/issues/388

* adds an accessor function in the Acceptor struct in order to return the net.Addr of the listener, we do not return the listener itself to avoid accessing other functions such as Close()

As per now Acceptor does not have a testing suite, hence no tests being added to this PR. Following Contributions guidelines it should still be fine, let me know if anything else is required/needed