### PR TITLE
Expose IP address for Acceptor 

### DIFF
--- a/acceptor.go
+++ b/acceptor.go
@@ -101,6 +101,7 @@ func (a *Acceptor) Stop() {
 	a.sessionGroup.Wait()
 }
 
+//Get remote IP address for a given session.
 func (a *Acceptor) RemoteAddr(sessionID SessionID) (net.Addr, bool) {
 	addr, ok := a.sessionAddr[sessionID]
 	return addr, ok

--- a/acceptor.go
+++ b/acceptor.go
@@ -28,6 +28,7 @@ type Acceptor struct {
 	dynamicQualifier      bool
 	dynamicQualifierCount int
 	dynamicSessionChan    chan *session
+	sessionAddr           map[SessionID]net.Addr
 	sessionFactory
 }
 
@@ -100,6 +101,11 @@ func (a *Acceptor) Stop() {
 	a.sessionGroup.Wait()
 }
 
+func (a *Acceptor) RemoteAddr(sessionID SessionID) (net.Addr, bool) {
+	addr, ok := a.sessionAddr[sessionID]
+	return addr, ok
+}
+
 //NewAcceptor creates and initializes a new Acceptor.
 func NewAcceptor(app Application, storeFactory MessageStoreFactory, settings *Settings, logFactory LogFactory) (a *Acceptor, err error) {
 	a = &Acceptor{
@@ -108,6 +114,7 @@ func NewAcceptor(app Application, storeFactory MessageStoreFactory, settings *Se
 		settings:     settings,
 		logFactory:   logFactory,
 		sessions:     make(map[SessionID]*session),
+		sessionAddr:  make(map[SessionID]net.Addr),
 	}
 	if a.settings.GlobalSettings().HasSetting(config.DynamicSessions) {
 		if a.dynamicSessions, err = settings.globalSettings.BoolSetting(config.DynamicSessions); err != nil {
@@ -265,6 +272,7 @@ func (a *Acceptor) handleConnection(netConn net.Conn) {
 		defer session.stop()
 	}
 
+	a.sessionAddr[sessID] = netConn.RemoteAddr()
 	msgIn := make(chan fixIn)
 	msgOut := make(chan []byte)
 
@@ -309,7 +317,13 @@ LOOP:
 				complete <- sessionID
 			}()
 		case id := <-complete:
-			delete(sessions, id)
+			session, ok := sessions[id]
+			if ok {
+				delete(a.sessionAddr, session.sessionID)
+				delete(sessions, id)
+			} else {
+				a.globalLog.OnEventf("Missing dynamic session %v!", id)
+			}
 		}
 	}
 


### PR DESCRIPTION
As described in https://github.com/quickfixgo/quickfix/issues/388 I'd like to implement IP whitelisting functionality.

I've noticed that QuickFIX/J implements this functionality through the `AllowedRemoteAddresses` config (_"List of remote IP addresses which are allowed to connect to this acceptor"_):
https://www.quickfixj.org/usermanual/2.1.0/usage/configuration.html 
While this is a good solution for static sessions, it doesn't work for my use-case because I'm using dynamic sessions. 

The simplest solution I could think of was to add a `RemoteAddr(sessionID)` method on the Acceptor that can be used to get the address for a particular session. 

