### PR TITLE
Lightweight support for Postgresql

### DIFF
--- a/sqlstore_test.go
+++ b/sqlstore_test.go
@@ -60,6 +60,11 @@ TargetCompID=%s`, sqlDriver, sqlDsn, sessionID.BeginString, sessionID.SenderComp
 	require.Nil(suite.T(), err)
 }
 
+func (suite *SQLStoreTestSuite) TestSqlPlaceholderReplacement() {
+	got := sqlString("A ? B ? C ?", postgresPlaceholder)
+	suite.Equal("A $1 B $2 C $3", got)
+}
+
 func (suite *SQLStoreTestSuite) TearDownTest() {
 	suite.msgStore.Close()
 	os.RemoveAll(suite.sqlStoreRootPath)


### PR DESCRIPTION
Addresses https://github.com/quickfixgo/quickfix/issues/284 without an overhaul 

- Adds a function to replace `?` placeholders with `$1` `$2` etc as required by postgres
- Runs all sql statements through the replacement func at query time (nop for sql)
- In theory any other placeholder format could be added pretty easily on top

