### PR TITLE
An option for a custom authentication logic

### DIFF
--- a/acceptor.go
+++ b/acceptor.go
@@ -40,15 +40,6 @@ type ConnectionValidator interface {
 	Validate(netConn net.Conn, session SessionID) error
 }
 
-// SetConnectionValidator sets an optional connection validator.
-// Use it when you need a custom authentication logic that includes lower level interactions,
-// like mTLS auth or IP whitelistening.
-// To remove a previously set validator call it with a nil value:
-// 	a.SetConnectionValidator(nil)
-func (a *Acceptor) SetConnectionValidator(validator ConnectionValidator) {
-	a.connectionValidator = validator
-}
-
 //Start accepting connections.
 func (a *Acceptor) Start() error {
 	socketAcceptHost := ""
@@ -364,4 +355,13 @@ LOOP:
 			return
 		}
 	}
+}
+
+// SetConnectionValidator sets an optional connection validator.
+// Use it when you need a custom authentication logic that includes lower level interactions,
+// like mTLS auth or IP whitelistening.
+// To remove a previously set validator call it with a nil value:
+// 	a.SetConnectionValidator(nil)
+func (a *Acceptor) SetConnectionValidator(validator ConnectionValidator) {
+	a.connectionValidator = validator
 }

--- a/acceptor.go
+++ b/acceptor.go
@@ -29,7 +29,24 @@ type Acceptor struct {
 	dynamicQualifierCount int
 	dynamicSessionChan    chan *session
 	sessionAddr           map[SessionID]net.Addr
+	connectionValidator   ConnectionValidator
 	sessionFactory
+}
+
+// ConnectionValidator is an interface allowing to implement a custom authentication logic.
+type ConnectionValidator interface {
+	// Validate the connection for validity. This can be a part of authentication process.
+	// For example, you may tie up a SenderCompID to an IP range, or to a specific TLS certificate as a part of mTLS.
+	Validate(netConn net.Conn, session SessionID) error
+}
+
+// SetConnectionValidator sets an optional connection validator.
+// Use it when you need a custom authentication logic that includes lower level interactions,
+// like mTLS auth or IP whitelistening.
+// To remove a previously set validator call it with a nil value:
+// 	a.SetConnectionValidator(nil)
+func (a *Acceptor) SetConnectionValidator(validator ConnectionValidator) {
+	a.connectionValidator = validator
 }
 
 //Start accepting connections.
@@ -253,6 +270,15 @@ func (a *Acceptor) handleConnection(netConn net.Conn) {
 		SenderCompID: string(targetCompID), SenderSubID: string(targetSubID), SenderLocationID: string(targetLocationID),
 		TargetCompID: string(senderCompID), TargetSubID: string(senderSubID), TargetLocationID: string(senderLocationID),
 	}
+
+	// We have a session ID and a network connection. This seems to be a good place for any custom authentication logic.
+	if a.connectionValidator != nil {
+		if err := a.connectionValidator.Validate(netConn, sessID); err != nil {
+			a.globalLog.OnEventf("Unable to validate a connection %v", err.Error())
+			return
+		}
+	}
+
 	if a.dynamicQualifier {
 		a.dynamicQualifierCount++
 		sessID.Qualifier = strconv.Itoa(a.dynamicQualifierCount)


### PR DESCRIPTION
Adding ConnectionValidator interface allows implementation of any customer's validation/authentication. Possible use cases may include mutual TLS authentication or IP white-listening tied up with certain SenderCompID. The validator is optional and the behaviour of existing clients will not change.
This will also address #388 
The `Acceptor` is unfortunately not covered with tests and covering `handleConnection` to verify the validator is working as expected will require a significant refactoring, or a more end-to-end style test.
Any feedback is welcome, if there are other ways to handle the strict mTLS auth that I've not found yet - please let me know.