### PR TITLE
Avoid to block thread while write to a nil channel

### DIFF
--- a/session.go
+++ b/session.go
@@ -367,6 +367,11 @@ func (s *session) EnqueueBytesAndSend(msg []byte) {
 }
 
 func (s *session) sendBytes(msg []byte) {
+	if s.messageOut == nil {
+		s.log.OnEventf("Failed to send: disconnected")
+		return
+	}
+
 	s.log.OnOutgoing(msg)
 	s.messageOut <- msg
 	s.stateTimer.Reset(s.HeartBtInt)


### PR DESCRIPTION
if session disconnected during sendBytes, session.messageOut
may be set to nil before write in session.onDisconnect()