### PR TITLE
Fix sequence number bug when storage fails

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -278,34 +278,34 @@ func (store *fileStore) NextTargetMsgSeqNum() int {
 
 // SetNextSenderMsgSeqNum sets the next MsgSeqNum that will be sent.
 func (store *fileStore) SetNextSenderMsgSeqNum(next int) error {
-	if err := store.cache.SetNextSenderMsgSeqNum(next); err != nil {
-		return errors.Wrap(err, "cache")
+	if err := store.setSeqNum(store.senderSeqNumsFile, next); err != nil {
+		return errors.Wrap(err, "file")
 	}
-	return store.setSeqNum(store.senderSeqNumsFile, next)
+	return store.cache.SetNextSenderMsgSeqNum(next)
 }
 
 // SetNextTargetMsgSeqNum sets the next MsgSeqNum that should be received.
 func (store *fileStore) SetNextTargetMsgSeqNum(next int) error {
-	if err := store.cache.SetNextTargetMsgSeqNum(next); err != nil {
-		return errors.Wrap(err, "cache")
+	if err := store.setSeqNum(store.targetSeqNumsFile, next); err != nil {
+		return errors.Wrap(err, "file")
 	}
-	return store.setSeqNum(store.targetSeqNumsFile, next)
+	return store.cache.SetNextTargetMsgSeqNum(next)
 }
 
 // IncrNextSenderMsgSeqNum increments the next MsgSeqNum that will be sent.
 func (store *fileStore) IncrNextSenderMsgSeqNum() error {
-	if err := store.cache.IncrNextSenderMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache")
+	if err := store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "file")
 	}
-	return store.setSeqNum(store.senderSeqNumsFile, store.cache.NextSenderMsgSeqNum())
+	return nil
 }
 
 // IncrNextTargetMsgSeqNum increments the next MsgSeqNum that should be received.
 func (store *fileStore) IncrNextTargetMsgSeqNum() error {
-	if err := store.cache.IncrNextTargetMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache")
+	if err := store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "file")
 	}
-	return store.setSeqNum(store.targetSeqNumsFile, store.cache.NextTargetMsgSeqNum())
+	return nil
 }
 
 // CreationTime returns the creation time of the store.

--- a/mongostore.go
+++ b/mongostore.go
@@ -254,18 +254,18 @@ func (store *mongoStore) SetNextTargetMsgSeqNum(next int) error {
 
 // IncrNextSenderMsgSeqNum increments the next MsgSeqNum that will be sent.
 func (store *mongoStore) IncrNextSenderMsgSeqNum() error {
-	if err := store.cache.IncrNextSenderMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache incr")
+	if err := store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "save sequence number")
 	}
-	return store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum())
+	return nil
 }
 
 // IncrNextTargetMsgSeqNum increments the next MsgSeqNum that should be received.
 func (store *mongoStore) IncrNextTargetMsgSeqNum() error {
-	if err := store.cache.IncrNextTargetMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache incr")
+	if err := store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "save sequence number")
 	}
-	return store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum())
+	return nil
 }
 
 // CreationTime returns the creation time of the store.

--- a/sqlstore.go
+++ b/sqlstore.go
@@ -261,18 +261,18 @@ func (store *sqlStore) SetNextTargetMsgSeqNum(next int) error {
 
 // IncrNextSenderMsgSeqNum increments the next MsgSeqNum that will be sent.
 func (store *sqlStore) IncrNextSenderMsgSeqNum() error {
-	if err := store.cache.IncrNextSenderMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache incr next")
+	if err := store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "store next")
 	}
-	return store.SetNextSenderMsgSeqNum(store.cache.NextSenderMsgSeqNum())
+	return nil
 }
 
 // IncrNextTargetMsgSeqNum increments the next MsgSeqNum that should be received.
 func (store *sqlStore) IncrNextTargetMsgSeqNum() error {
-	if err := store.cache.IncrNextTargetMsgSeqNum(); err != nil {
-		return errors.Wrap(err, "cache incr next")
+	if err := store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum() + 1); err != nil {
+		return errors.Wrap(err, "store next")
 	}
-	return store.SetNextTargetMsgSeqNum(store.cache.NextTargetMsgSeqNum())
+	return nil
 }
 
 // CreationTime returns the creation time of the store.


### PR DESCRIPTION
If update sequence number cache before store it to mongodb, sql or file, and then get an error, will cause the sequence number to be discontinuous. So, store sequence number before update cache.