### PR TITLE
add ParseSrc function so the source of the datadict doesn't have to be a filepath.

### DIFF
--- a/datadictionary/datadictionary.go
+++ b/datadictionary/datadictionary.go
@@ -3,6 +3,7 @@ package datadictionary
 
 import (
 	"encoding/xml"
+	"io"
 	"os"
 )
 
@@ -305,15 +306,20 @@ func Parse(path string) (*DataDictionary, error) {
 	}
 	defer xmlFile.Close()
 
+	return ParseSrc(xmlFile)
+}
+
+//ParseSrc loads and and build a datadictionary instance from an xml source.
+func ParseSrc(xmlSrc io.Reader) (*DataDictionary, error) {
 	doc := new(XMLDoc)
-	decoder := xml.NewDecoder(xmlFile)
+	decoder := xml.NewDecoder(xmlSrc)
 	if err := decoder.Decode(doc); err != nil {
 		return nil, err
 	}
 
 	b := new(builder)
-	var dict *DataDictionary
-	if dict, err = b.build(doc); err != nil {
+	dict, err := b.build(doc)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
instead of having to provide a path it would be nice if we could provide the src ourselves, as this allows embedding the src into the binary, for example with `go:embed` added in go 1.16 :)

this seems to be the simplest way of making this possible without having to expose the `builder` and allows anyone to provide the source of the datadict in any way they like as a simple `bytes.NewBuffer([]byte{})` or with anything else that provides a `io.Reader`!