### PR TITLE
Component should never be a pointer

### DIFF
--- a/cmd/generate-fix/internal/template_helpers.go
+++ b/cmd/generate-fix/internal/template_helpers.go
@@ -258,7 +258,7 @@ func requiredFields(m *datadictionary.MessageDef) (required []*datadictionary.Fi
 				if !pType.IsGroup() {
 					required = append(required, pType)
 				}
-			case *datadictionary.Component:
+			case datadictionary.Component:
 				for _, f := range pType.RequiredFields() {
 					if !f.IsGroup() {
 						required = append(required, f)

--- a/cmd/generate-fix/internal/template_helpers_test.go
+++ b/cmd/generate-fix/internal/template_helpers_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/quickfixgo/quickfix/datadictionary"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiredFieldsRequiredComponent(t *testing.T) {
+	ft1 := datadictionary.NewFieldType("type1", 11, "STRING")
+
+	requiredfd1 := datadictionary.NewFieldDef(ft1, true)
+	ct1 := datadictionary.NewComponentType("ct1", []datadictionary.MessagePart{requiredfd1})
+
+	// when the component is optional the fields shouldn't be considered required
+	{
+		md := datadictionary.NewMessageDef("some message", "X", []datadictionary.MessagePart{
+			datadictionary.NewComponent(ct1, false),
+		})
+
+		res := requiredFields(md)
+		assert.Len(t, res, 0)
+	}
+
+	// when the component is required the fields should be considered required
+	{
+		md := datadictionary.NewMessageDef("some message", "X", []datadictionary.MessagePart{
+			datadictionary.NewComponent(ct1, true),
+		})
+
+		res := requiredFields(md)
+		assert.Len(t, res, 1)
+	}
+}

--- a/datadictionary/component_type_test.go
+++ b/datadictionary/component_type_test.go
@@ -68,12 +68,14 @@ func TestNewComponentType(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ct := datadictionary.NewComponentType("cname", test.parts)
-		assert.NotNil(t, ct, test.testName)
-		assert.Equal(t, "cname", ct.Name(), test.testName)
-		assert.Equal(t, test.expectedFields, ct.Fields(), test.testName)
-		assert.Equal(t, test.parts, ct.Parts(), test.testName)
-		assert.Equal(t, test.expectedRequiredFields, ct.RequiredFields(), test.testName)
-		assert.Equal(t, test.expectedRequiredParts, ct.RequiredParts(), test.testName)
+		t.Run(test.testName, func(t *testing.T) {
+			ct := datadictionary.NewComponentType("cname", test.parts)
+			assert.NotNil(t, ct, test.testName)
+			assert.Equal(t, "cname", ct.Name(), test.testName)
+			assert.Equal(t, test.expectedFields, ct.Fields(), test.testName)
+			assert.Equal(t, test.parts, ct.Parts(), test.testName)
+			assert.Equal(t, test.expectedRequiredFields, ct.RequiredFields(), test.testName)
+			assert.Equal(t, test.expectedRequiredParts, ct.RequiredParts(), test.testName)
+		})
 	}
 }

--- a/datadictionary/datadictionary.go
+++ b/datadictionary/datadictionary.go
@@ -106,8 +106,8 @@ type Component struct {
 }
 
 //NewComponent returns an initialized Component instance
-func NewComponent(ct *ComponentType, required bool) *Component {
-	return &Component{
+func NewComponent(ct *ComponentType, required bool) Component {
+	return Component{
 		ComponentType: ct,
 		required:      required,
 	}


### PR DESCRIPTION
changed all usage of `Component` to always be on `Component`, never `*Component`, this way the type switches actually work everywhere and consistently.  
Because both `*Component` and `Component` implement `MessagePart` it was being mixed up.

This fixes a bug in the generated code not considering required fields from required components to be required and thus they weren't added to the  `New()` constructor for a message.

I think this could be considered a BC break ..., not sure how you guys deal with that?  
If someone had a component with required fields which was marked as required then if they'd run `generate-fix` again the fields will be added to the arguments of `New()`... 
