### PR TITLE
Make use of SocketCAFile config

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -35,33 +35,36 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 	}
 
 	if !settings.HasSetting(config.SocketPrivateKeyFile) && !settings.HasSetting(config.SocketCertificateFile) {
-		if allowSkipClientCerts {
-			tlsConfig = defaultTLSConfig()
-			tlsConfig.ServerName = serverName
-			tlsConfig.InsecureSkipVerify = insecureSkipVerify
-			setMinVersionExplicit(settings, tlsConfig)
+		if !allowSkipClientCerts {
+			return
 		}
-		return
-	}
-
-	privateKeyFile, err := settings.Setting(config.SocketPrivateKeyFile)
-	if err != nil {
-		return
-	}
-
-	certificateFile, err := settings.Setting(config.SocketCertificateFile)
-	if err != nil {
-		return
 	}
 
 	tlsConfig = defaultTLSConfig()
-	tlsConfig.Certificates = make([]tls.Certificate, 1)
 	tlsConfig.ServerName = serverName
 	tlsConfig.InsecureSkipVerify = insecureSkipVerify
 	setMinVersionExplicit(settings, tlsConfig)
 
-	if tlsConfig.Certificates[0], err = tls.LoadX509KeyPair(certificateFile, privateKeyFile); err != nil {
-		return
+	if settings.HasSetting(config.SocketPrivateKeyFile) && settings.HasSetting(config.SocketCertificateFile) {
+
+		var privateKeyFile string
+		var certificateFile string
+
+		privateKeyFile, err = settings.Setting(config.SocketPrivateKeyFile)
+		if err != nil {
+			return
+		}
+
+		certificateFile, err = settings.Setting(config.SocketCertificateFile)
+		if err != nil {
+			return
+		}
+
+		tlsConfig.Certificates = make([]tls.Certificate, 1)
+
+		if tlsConfig.Certificates[0], err = tls.LoadX509KeyPair(certificateFile, privateKeyFile); err != nil {
+			return
+		}
 	}
 
 	if !settings.HasSetting(config.SocketCAFile) {
@@ -86,7 +89,10 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 
 	tlsConfig.RootCAs = certPool
 	tlsConfig.ClientCAs = certPool
-	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+
+	if !allowSkipClientCerts {
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
 
 	return
 }

--- a/tls.go
+++ b/tls.go
@@ -67,6 +67,10 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 		}
 	}
 
+	if !allowSkipClientCerts {
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
 	if !settings.HasSetting(config.SocketCAFile) {
 		return
 	}
@@ -89,10 +93,6 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 
 	tlsConfig.RootCAs = certPool
 	tlsConfig.ClientCAs = certPool
-
-	if !allowSkipClientCerts {
-		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	}
 
 	return
 }

--- a/tls.go
+++ b/tls.go
@@ -45,7 +45,7 @@ func loadTLSConfig(settings *SessionSettings) (tlsConfig *tls.Config, err error)
 	tlsConfig.InsecureSkipVerify = insecureSkipVerify
 	setMinVersionExplicit(settings, tlsConfig)
 
-	if settings.HasSetting(config.SocketPrivateKeyFile) && settings.HasSetting(config.SocketCertificateFile) {
+	if settings.HasSetting(config.SocketPrivateKeyFile) || settings.HasSetting(config.SocketCertificateFile) {
 
 		var privateKeyFile string
 		var certificateFile string

--- a/tls_test.go
+++ b/tls_test.go
@@ -60,7 +60,7 @@ func (s *TLSTestSuite) TestLoadTLSNoCA() {
 	s.Len(tlsConfig.Certificates, 1)
 	s.Nil(tlsConfig.RootCAs)
 	s.Nil(tlsConfig.ClientCAs)
-	s.Equal(tls.NoClientCert, tlsConfig.ClientAuth)
+	s.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 }
 
 func (s *TLSTestSuite) TestLoadTLSWithBadCA() {
@@ -105,6 +105,16 @@ func (s *TLSTestSuite) TestLoadTLSWithoutSSLWithOnlyCA() {
 	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
 	s.Nil(err)
 	s.Nil(tlsConfig)
+}
+
+func (s *TLSTestSuite) TestLoadTLSAllowSkipClientCerts() {
+	s.settings.GlobalSettings().Set(config.SocketUseSSL, "Y")
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+
+	s.Equal(tls.NoClientCert, tlsConfig.ClientAuth)
 }
 
 func (s *TLSTestSuite) TestServerNameUseSSL() {

--- a/tls_test.go
+++ b/tls_test.go
@@ -87,6 +87,26 @@ func (s *TLSTestSuite) TestLoadTLSWithCA() {
 	s.Equal(tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 }
 
+func (s *TLSTestSuite) TestLoadTLSWithOnlyCA() {
+	s.settings.GlobalSettings().Set(config.SocketUseSSL, "Y")
+	s.settings.GlobalSettings().Set(config.SocketCAFile, s.CAFile)
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.NotNil(tlsConfig)
+
+	s.NotNil(tlsConfig.RootCAs)
+	s.NotNil(tlsConfig.ClientCAs)
+}
+
+func (s *TLSTestSuite) TestLoadTLSWithoutSSLWithOnlyCA() {
+	s.settings.GlobalSettings().Set(config.SocketCAFile, s.CAFile)
+
+	tlsConfig, err := loadTLSConfig(s.settings.GlobalSettings())
+	s.Nil(err)
+	s.Nil(tlsConfig)
+}
+
 func (s *TLSTestSuite) TestServerNameUseSSL() {
 	s.settings.GlobalSettings().Set(config.SocketUseSSL, "Y")
 	s.settings.GlobalSettings().Set(config.SocketServerName, "DummyServerNameUseSSL")


### PR DESCRIPTION
I think the `SocketUseSSL` config actually makes the code skips the `SocketCAFile` config when it is set to `Y`. 

Since we have `SocketCAFile` option to use a supplied CA certificate to verify server identity, we still need the part of the code to add the supplied CA certificate to the `CertPool` and other functionalities. Skipping client authentication shouldn't skip everything.