### PR TITLE
Fix repeating group read tags lost

### DIFF
--- a/repeating_group.go
+++ b/repeating_group.go
@@ -202,6 +202,7 @@ func (f *RepeatingGroup) Read(tv []TagValue) ([]TagValue, error) {
 
 		group.rwLock.Lock()
 		group.tagLookup[tvRange[0].tag] = tvRange
+		group.tags = append(group.tags, gi.Tag())
 		group.rwLock.Unlock()
 	}
 

--- a/repeating_group_test.go
+++ b/repeating_group_test.go
@@ -185,6 +185,8 @@ func TestRepeatingGroup_Read(t *testing.T) {
 			for _, expected := range test.expectedGroupTvs[g] {
 				var actual FIXString
 				require.Nil(t, group.GetField(expected.tag, &actual))
+				require.NotNil(t, group.tags)
+				require.Equal(t, len(group.tags), len(group.tagLookup))
 
 				if !bytes.Equal(expected.value, []byte(actual)) {
 					t.Errorf("%v, %v: expected %s, got %s", g, expected.tag, expected.value, actual)


### PR DESCRIPTION
The ```RepeatingGroup``` tags are not created during the read process. Tag values are there but tags are not copied over / read. If `CopyInto` is used to copy from old `FieldMap` to new, existing tags from old one will be lost during the [fields setting process](https://github.com/quickfixgo/quickfix/blob/main/repeating_group.go#L116)

Can try to reproduce like this: 

```go
	symGroup := quoterequest.NewNoRelatedSymRepeatingGroup()
	sym := symGroup.Add()
	sym.SetSymbol("symbol")
	sym.SetOrderQty(decimal.NewFromFloat(1), 4)
	sym.SetQuoteRequestType(enum.QuoteRequestType_AUTOMATIC)
	
	fixmsg := quoterequest.New(field.NewQuoteReqID("testId"))
	fixmsg.SetNoRelatedSym(symGroup)

	msg := quoterequest.FromMessage(fixmsg.ToMessage())
	if syms, err := msg.GetNoRelatedSym(); err == nil {

		newSyms := quoterequest.NewNoRelatedSymRepeatingGroup()
		newSym := newSyms.Add()

		sym := syms.Get(0)
		sym.CopyInto(&newSym.FieldMap) // SUT

		newSym.SetCurrency("USD")
		msg.SetNoRelatedSym(newSyms)
		// log msg.ToMessage() will show only Currency (15) tag
		// 8=FIX.4.4 9=29 35=R 131=testId 146=1 15=USD 10=213 
		// Whereas it should be
		// 8=FIX.4.4 9=55 35=R 131=testId 146=1 55=symbol 303=2 38=1.0000 15=USD 10=224
	}
```