### PR TITLE
use MaxInt32 values to enable compilation on 32-bit systems

### DIFF
--- a/repeating_group.go
+++ b/repeating_group.go
@@ -144,8 +144,8 @@ func (f RepeatingGroup) groupTagOrder() tagOrder {
 	}
 
 	return func(i, j Tag) bool {
-		orderi := math.MaxInt64
-		orderj := math.MaxInt64
+		orderi := math.MaxInt32
+		orderj := math.MaxInt32
 
 		if iIndex, ok := tagMap[i]; ok {
 			orderi = iIndex


### PR DESCRIPTION
Use of `MaxInt64` prevents compilation on 32-bit systems