### PR TITLE
Allow stores to fall back to global settings for dynamic sessions

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -61,10 +61,18 @@ func NewFileStoreFactory(settings *Settings) MessageStoreFactory {
 
 // Create creates a new FileStore implementation of the MessageStore interface.
 func (f fileStoreFactory) Create(sessionID SessionID) (msgStore MessageStore, err error) {
+	globalSettings := f.settings.GlobalSettings()
+	dynamicSessions, _ := globalSettings.BoolSetting(config.DynamicSessions)
+
 	sessionSettings, ok := f.settings.SessionSettings()[sessionID]
 	if !ok {
-		return nil, fmt.Errorf("unknown session: %v", sessionID)
+		if dynamicSessions {
+			sessionSettings = globalSettings
+		} else {
+			return nil, fmt.Errorf("unknown session: %v", sessionID)
+		}
 	}
+
 	dirname, err := sessionSettings.Setting(config.FileStorePath)
 	if err != nil {
 		return nil, err

--- a/sqlstore.go
+++ b/sqlstore.go
@@ -67,10 +67,18 @@ func NewSQLStoreFactory(settings *Settings) MessageStoreFactory {
 
 // Create creates a new SQLStore implementation of the MessageStore interface.
 func (f sqlStoreFactory) Create(sessionID SessionID) (msgStore MessageStore, err error) {
+	globalSettings := f.settings.GlobalSettings()
+	dynamicSessions, _ := globalSettings.BoolSetting(config.DynamicSessions)
+
 	sessionSettings, ok := f.settings.SessionSettings()[sessionID]
 	if !ok {
-		return nil, fmt.Errorf("unknown session: %v", sessionID)
+		if dynamicSessions {
+			sessionSettings = globalSettings
+		} else {
+			return nil, fmt.Errorf("unknown session: %v", sessionID)
+		}
 	}
+
 	sqlDriver, err := sessionSettings.Setting(config.SQLStoreDriver)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Dynamic sessions are not added to the settings until after the session
  factory has created the sessions. In this scenario the filestore and
  sqlstore are unable to get the settings and fail to create the various
  message stores. Often these settings are set globally so we should try
  falling back before failing to create the message store.

Fixes #484 