### PR TITLE
Add session outgoing message rate limit

### DIFF
--- a/acceptor.go
+++ b/acceptor.go
@@ -337,7 +337,7 @@ func (a *Acceptor) handleConnection(netConn net.Conn) {
 		readLoop(parser, msgIn)
 	}()
 
-	writeLoop(netConn, msgOut, a.globalLog)
+	writeLoop(netConn, msgOut, a.globalLog, session.MaxMessagesPerSecond)
 }
 
 func (a *Acceptor) dynamicSessionsLoop() {

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -48,6 +48,7 @@ const (
 	LogonTimeout                 string = "LogonTimeout"
 	HeartBtInt                   string = "HeartBtInt"
 	HeartBtIntOverride           string = "HeartBtIntOverride"
+	MaxMessagesPerSecond         string = "MaxMessagesPerSecond"
 	FileLogPath                  string = "FileLogPath"
 	FileStorePath                string = "FileStorePath"
 	SQLStoreDriver               string = "SQLStoreDriver"

--- a/config/doc.go
+++ b/config/doc.go
@@ -254,6 +254,12 @@ If set to Y, will use the HeartBtInt interval rather than what the initiator dic
 
 Defaults to N.
 
+MaxMessagesPerSecond
+
+Maximum number of messages to send per second. This is a per session rate limit to support throttling outgoing messages to accommodate counterparties with messaging rate restrictions. A value of 0 means no limiting is applied. Value must be 0 or a positive integer.
+
+Defaults to 0
+
 SocketConnectPort
 
 Socket port for connecting to a session. Only used for initiators. Must be positive integer

--- a/connection.go
+++ b/connection.go
@@ -1,12 +1,31 @@
 package quickfix
 
-import "io"
+import (
+	"context"
+	"io"
 
-func writeLoop(connection io.Writer, messageOut chan []byte, log Log) {
+	"golang.org/x/time/rate"
+)
+
+const maxBurst = 1
+
+func writeLoop(connection io.Writer, messageOut chan []byte, log Log, maxMessagesPerSecond int) {
+	limiter := rate.NewLimiter(rate.Limit(maxMessagesPerSecond), maxBurst)
+	ctx := context.Background()
+
 	for {
 		msg, ok := <-messageOut
 		if !ok {
 			return
+		}
+
+		if maxMessagesPerSecond > 0 {
+			err := limiter.Wait(ctx)
+			// if we get an error from the limiter we log, but continue on to
+			// attempt to write the message to the remote party
+			if err != nil {
+				log.OnEvent(err.Error())
+			}
 		}
 
 		if _, err := connection.Write(msg); err != nil {

--- a/connection_internal_test.go
+++ b/connection_internal_test.go
@@ -16,7 +16,7 @@ func TestWriteLoop(t *testing.T) {
 		msgOut <- []byte("test msg 3")
 		close(msgOut)
 	}()
-	writeLoop(writer, msgOut, nullLog{})
+	writeLoop(writer, msgOut, nullLog{}, 0)
 
 	expected := "test msg 1 test msg 2 test msg 3"
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,10 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/net v0.0.0-20220708220712-1185a9018129
+	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
 golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 h1:ftMN5LMiBFjbzleLqtoBZk7KdJwhuybIU+FckUHgoyQ=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/initiator.go
+++ b/initiator.go
@@ -179,7 +179,7 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 		go readLoop(newParser(bufio.NewReader(netConn)), msgIn)
 		disconnected = make(chan interface{})
 		go func() {
-			writeLoop(netConn, msgOut, session.log)
+			writeLoop(netConn, msgOut, session.log, session.MaxMessagesPerSecond)
 			if err := netConn.Close(); err != nil {
 				session.log.OnEvent(err.Error())
 			}

--- a/internal/session_settings.go
+++ b/internal/session_settings.go
@@ -10,6 +10,7 @@ type SessionSettings struct {
 	ResetOnDisconnect            bool
 	HeartBtInt                   time.Duration
 	HeartBtIntOverride           bool
+	MaxMessagesPerSecond         int
 	SessionTime                  *TimeRange
 	InitiateLogon                bool
 	ResendRequestChunkSize       int
@@ -18,7 +19,7 @@ type SessionSettings struct {
 	MaxLatency                   time.Duration
 	DisableMessagePersist        bool
 
-	//required on logon for FIX.T.1 messages
+	//required on logon for FIXT.1.1 messages
 	DefaultApplVerID string
 
 	//specific to initiators

--- a/session_factory.go
+++ b/session_factory.go
@@ -334,6 +334,11 @@ func (f sessionFactory) buildAcceptorSettings(session *session, settings *Sessio
 	if err := f.buildHeartBtIntSettings(session, settings, false); err != nil {
 		return err
 	}
+
+	if err := f.buildMaxMessagesPerSecondSettings(session, settings); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -341,6 +346,10 @@ func (f sessionFactory) buildInitiatorSettings(session *session, settings *Sessi
 	session.InitiateLogon = true
 
 	if err := f.buildHeartBtIntSettings(session, settings, true); err != nil {
+		return err
+	}
+
+	if err := f.buildMaxMessagesPerSecondSettings(session, settings); err != nil {
 		return err
 	}
 
@@ -440,5 +449,20 @@ func (f sessionFactory) buildHeartBtIntSettings(session *session, settings *Sess
 		}
 		session.HeartBtInt = time.Duration(heartBtInt) * time.Second
 	}
+	return
+}
+
+func (f sessionFactory) buildMaxMessagesPerSecondSettings(session *session, settings *SessionSettings) (err error) {
+	session.MaxMessagesPerSecond = 0
+	if settings.HasSetting(config.MaxMessagesPerSecond) {
+		if session.MaxMessagesPerSecond, err = settings.IntSetting(config.MaxMessagesPerSecond); err != nil {
+			return
+		}
+
+		if session.MaxMessagesPerSecond < 0 {
+			return errors.New("MaxMessagesPerSecond must be greater than or equal to zero")
+		}
+	}
+
 	return
 }


### PR DESCRIPTION
This feature was required for an integration we are currently working on with a very large exchange. At this exchange in their test environment our application is limited to just 10 msg/sec/session, while in production this limit increases to 1000 msg/sec/session.

In either case we needed a way to ensure we never burst above this limit as this leads to temporary disconnection (which we did see happening with the 10 msg/sec/session limit in the UAT environment due to the way QuickFIX batches outgoing messages), so this PR adds a rate limiter to the session configuration such that we can enforce per session outgoing rate
limits.

If no limit is specified for a session it defaults to a limit value of 0, meaning that no limiting is enforced for backwards compatibility with existing deployments.