### PR TITLE
Add Weekdays config setting as included in QuickFIX/J

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -2,7 +2,7 @@ package config
 
 //NOTE: Additions to this file should be made to both config/doc.go and http://www.quickfixgo.org/docs/
 
-//Const configuration settings
+// Const configuration settings
 const (
 	BeginString                  string = "BeginString"
 	SenderCompID                 string = "SenderCompID"
@@ -35,6 +35,7 @@ const (
 	EndTime                      string = "EndTime"
 	StartDay                     string = "StartDay"
 	EndDay                       string = "EndDay"
+	Weekdays                     string = "Weekdays"
 	TimeZone                     string = "TimeZone"
 	DataDictionary               string = "DataDictionary"
 	TransportDataDictionary      string = "TransportDataDictionary"

--- a/config/doc.go
+++ b/config/doc.go
@@ -84,15 +84,21 @@ Time of day that this FIX session becomes deactivated. Valid Values:
 
 StartDay
 
-For week long sessions, the starting day of week for the session. Use in combination with StartTime. Valid Values:
+For week long sessions, the starting day of week for the session. Use in combination with StartTime. Incompatible with Weekdays. Valid Values:
 
  Full day of week in English, or 3 letter abbreviation (i.e. Monday and Mon are valid)
 
 EndDay
 
-For week long sessions, the ending day of week for the session. Use in combination with EndTime. Valid Values:
+For week long sessions, the ending day of week for the session. Use in combination with EndTime. Incompatible with Weekdays. Valid Values:
 
  Full day of week in English, or 3 letter abbreviation (i.e. Monday and Mon are valid)
+
+Weekdays
+
+For daily sessions that are only active on specific days of the week. Use in combination with StartTime and EndTime. Incompatible with StartDay and EndDay. Valid Values:
+
+ Comma delimited list of days of the week in English, or 3 letter abbreviation (e.g. "Monday,Tuesday,Wednesday" or "Mon,Tue,Wed" would both be valid values)
 
 EnableLastMsgSeqNumProcessed
 

--- a/internal/time_range.go
+++ b/internal/time_range.go
@@ -36,41 +36,64 @@ func ParseTimeOfDay(str string) (TimeOfDay, error) {
 //TimeRange represents a time band in a given time zone
 type TimeRange struct {
 	startTime, endTime TimeOfDay
+	weekdays           []time.Weekday
 	startDay, endDay   *time.Weekday
 	loc                *time.Location
 }
 
 //NewUTCTimeRange returns a time range in UTC
-func NewUTCTimeRange(start, end TimeOfDay) *TimeRange {
-	return NewTimeRangeInLocation(start, end, time.UTC)
+func NewUTCTimeRange(start, end TimeOfDay, weekdays []time.Weekday) (*TimeRange, error) {
+	return NewTimeRangeInLocation(start, end, weekdays, time.UTC)
 }
 
 //NewTimeRangeInLocation returns a time range in a given location
-func NewTimeRangeInLocation(start, end TimeOfDay, loc *time.Location) *TimeRange {
+func NewTimeRangeInLocation(start, end TimeOfDay, weekdays []time.Weekday, loc *time.Location) (*TimeRange, error) {
 	if loc == nil {
-		panic("time: missing Location in call to NewTimeRangeInLocation")
+		return nil, errors.New("time: missing Location in call to NewTimeRangeInLocation")
 	}
 
-	return &TimeRange{startTime: start, endTime: end, loc: loc}
+	return &TimeRange{
+		startTime: start,
+		endTime:   end,
+		weekdays:  weekdays,
+		loc:       loc,
+	}, nil
 }
 
 //NewUTCWeekRange returns a weekly TimeRange
-func NewUTCWeekRange(startTime, endTime TimeOfDay, startDay, endDay time.Weekday) *TimeRange {
+func NewUTCWeekRange(startTime, endTime TimeOfDay, startDay, endDay time.Weekday) (*TimeRange, error) {
 	return NewWeekRangeInLocation(startTime, endTime, startDay, endDay, time.UTC)
 }
 
-//NewWeekRangeInLocation returns a time range in a given location
-func NewWeekRangeInLocation(startTime, endTime TimeOfDay, startDay, endDay time.Weekday, loc *time.Location) *TimeRange {
-	r := NewTimeRangeInLocation(startTime, endTime, loc)
+func NewWeekRangeInLocation(startTime, endTime TimeOfDay, startDay, endDay time.Weekday, loc *time.Location) (*TimeRange, error) {
+	r, err := NewTimeRangeInLocation(startTime, endTime, []time.Weekday{}, loc)
+	if err != nil {
+		return nil, err
+	}
 	r.startDay = &startDay
 	r.endDay = &endDay
 
-	return r
+	return r, nil
 }
 
 func (r *TimeRange) isInTimeRange(t time.Time) bool {
 	t = t.In(r.loc)
 	ts := NewTimeOfDay(t.Clock()).d
+
+	if len(r.weekdays) > 0 {
+		found := false
+
+		for _, weekday := range r.weekdays {
+			if t.Weekday() == weekday {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
 
 	if r.startTime.d < r.endTime.d {
 		return r.startTime.d <= ts && ts <= r.endTime.d

--- a/internal/time_range_test.go
+++ b/internal/time_range_test.go
@@ -31,49 +31,68 @@ func TestParseTime(t *testing.T) {
 }
 
 func TestNewUTCTimeRange(t *testing.T) {
-	r := NewUTCTimeRange(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0))
+	r, err := NewUTCTimeRange(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), []time.Weekday{})
+	assert.Nil(t, err)
 	assert.Equal(t, NewTimeOfDay(3, 0, 0), r.startTime)
 	assert.Equal(t, NewTimeOfDay(18, 0, 0), r.endTime)
+	assert.Equal(t, []time.Weekday{}, r.weekdays)
 	assert.Nil(t, r.startDay)
 	assert.Nil(t, r.endDay)
 	assert.Equal(t, time.UTC, r.loc)
 }
 
 func TestNewTimeRangeInLocation(t *testing.T) {
-	r := NewTimeRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Local)
+	r, err := NewTimeRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), []time.Weekday{}, time.Local)
+	assert.Nil(t, err)
 	assert.Equal(t, NewTimeOfDay(3, 0, 0), r.startTime)
 	assert.Equal(t, NewTimeOfDay(18, 0, 0), r.endTime)
+	assert.Equal(t, []time.Weekday{}, r.weekdays)
 	assert.Nil(t, r.startDay)
 	assert.Nil(t, r.endDay)
 	assert.Equal(t, time.Local, r.loc)
 }
 
+func TestNewTimeRangeInNilLocation(t *testing.T) {
+	_, err := NewTimeRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), []time.Weekday{}, nil)
+	assert.EqualError(t, err, "time: missing Location in call to NewTimeRangeInLocation")
+}
+
 func TestNewUTCWeekRange(t *testing.T) {
-	r := NewUTCWeekRange(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Monday, time.Wednesday)
+	r, err := NewUTCWeekRange(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Monday, time.Wednesday)
+	assert.Nil(t, err)
 	assert.Equal(t, NewTimeOfDay(3, 0, 0), r.startTime)
 	assert.Equal(t, NewTimeOfDay(18, 0, 0), r.endTime)
 	assert.NotNil(t, r.startDay)
 	assert.NotNil(t, r.endDay)
+	assert.Equal(t, []time.Weekday{}, r.weekdays)
 	assert.Equal(t, time.Monday, *r.startDay)
 	assert.Equal(t, time.Wednesday, *r.endDay)
 	assert.Equal(t, time.UTC, r.loc)
 }
 
 func TestNewWeekRangeInLocation(t *testing.T) {
-	r := NewWeekRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Monday, time.Wednesday, time.Local)
+	r, err := NewWeekRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Monday, time.Wednesday, time.Local)
+	assert.Nil(t, err)
 	assert.Equal(t, NewTimeOfDay(3, 0, 0), r.startTime)
 	assert.Equal(t, NewTimeOfDay(18, 0, 0), r.endTime)
 	assert.NotNil(t, r.startDay)
 	assert.NotNil(t, r.endDay)
+	assert.Equal(t, []time.Weekday{}, r.weekdays)
 	assert.Equal(t, time.Monday, *r.startDay)
 	assert.Equal(t, time.Wednesday, *r.endDay)
 	assert.Equal(t, time.Local, r.loc)
 }
 
+func TestNewWeekRangeInNilLocation(t *testing.T) {
+	_, err := NewWeekRangeInLocation(NewTimeOfDay(3, 0, 0), NewTimeOfDay(18, 0, 0), time.Monday, time.Wednesday, nil)
+	assert.EqualError(t, err, "time: missing Location in call to NewTimeRangeInLocation")
+}
+
 func BenchmarkInRange(b *testing.B) {
 	start := NewTimeOfDay(3, 0, 0)
 	end := NewTimeOfDay(18, 0, 0)
-	tr := NewUTCTimeRange(start, end)
+	weekdays := []time.Weekday{}
+	tr, _ := NewUTCTimeRange(start, end, weekdays)
 
 	now := time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
 	for n := 0; n < b.N; n++ {
@@ -82,355 +101,919 @@ func BenchmarkInRange(b *testing.B) {
 }
 
 func TestTimeRangeIsInRange(t *testing.T) {
-	start := NewTimeOfDay(3, 0, 0)
-	end := NewTimeOfDay(18, 0, 0)
+	testcases := []struct {
+		label           string
+		start           TimeOfDay
+		end             TimeOfDay
+		weekdays        []time.Weekday
+		location        *time.Location
+		now             time.Time
+		expectedInRange bool
+	}{
+		{
+			label:           "10AM",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "6PM",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "2AM",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 2, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "7PM",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "6:01PM",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 18, 1, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "6PM, inverted start/end",
+			start:           NewTimeOfDay(18, 0, 0),
+			end:             NewTimeOfDay(3, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "3AM, inverted start/end",
+			start:           NewTimeOfDay(18, 0, 0),
+			end:             NewTimeOfDay(3, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 3, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "4AM, inverted start/end",
+			start:           NewTimeOfDay(18, 0, 0),
+			end:             NewTimeOfDay(3, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 4, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "5PM, inverted start/end",
+			start:           NewTimeOfDay(18, 0, 0),
+			end:             NewTimeOfDay(3, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 17, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "3AM in fixed zone of -60",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(5, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.FixedZone("myzone", -60),
+			now:             time.Date(2016, time.August, 10, 3, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "3:01AM in fixed zone of -60",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(5, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.FixedZone("myzone", -60),
+			now:             time.Date(2016, time.August, 10, 3, 1, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "equal start/end",
+			start:           NewTimeOfDay(0, 0, 0),
+			end:             NewTimeOfDay(0, 0, 0),
+			weekdays:        []time.Weekday{},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "10AM, weekdays in range",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "10AM, weekdays out of range",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{time.Monday, time.Tuesday},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "2AM, weekdays in range",
+			start:           NewTimeOfDay(3, 0, 0),
+			end:             NewTimeOfDay(18, 0, 0),
+			weekdays:        []time.Weekday{time.Monday, time.Tuesday, time.Wednesday},
+			location:        time.UTC,
+			now:             time.Date(2016, time.August, 10, 2, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+	}
 
-	now := time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCTimeRange(start, end).IsInRange(now))
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			timeRange, err := NewTimeRangeInLocation(tc.start, tc.end, tc.weekdays, tc.location)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedInRange, timeRange.IsInRange(tc.now))
+		})
+	}
+}
 
-	now = time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 2, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 18, 0, 1, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	start = NewTimeOfDay(18, 0, 0)
-	end = NewTimeOfDay(3, 0, 0)
-	now = time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 3, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 4, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 17, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInRange(now))
+func TestTimeInRangeNil(t *testing.T) {
+	now := time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC)
 
 	var tr *TimeRange
-	assert.True(t, tr.IsInRange(now), "always in range if time range is nil")
-
-	loc := time.FixedZone("myzone", -60)
-	start = NewTimeOfDay(3, 0, 0)
-	end = NewTimeOfDay(5, 0, 0)
-
-	now = time.Date(2016, time.August, 10, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewTimeRangeInLocation(start, end, loc).IsInRange(now))
-
-	now = time.Date(2016, time.August, 10, 3, 1, 0, 0, time.UTC)
-	assert.True(t, NewTimeRangeInLocation(start, end, loc).IsInRange(now))
-
-	start = NewTimeOfDay(0, 0, 0)
-	end = NewTimeOfDay(0, 0, 0)
-	now = time.Date(2016, time.August, 10, 18, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCTimeRange(start, end).IsInRange(now))
-
+	assert.True(t, tr.IsInRange(now), "always in range if the time range is nil")
 }
 
 func TestTimeRangeIsInRangeWithDay(t *testing.T) {
+	testcases := []struct {
+		label           string
+		startTime       TimeOfDay
+		endTime         TimeOfDay
+		startDay        time.Weekday
+		endDay          time.Weekday
+		weekdays        []time.Weekday
+		location        *time.Location
+		now             time.Time
+		expectedInRange bool
+	}{
+		{
+			label:           "2AM Wednesday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 28, 2, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "6PM Tuesday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 27, 18, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "10PM Tuesday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 27, 22, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "3AM Tuesday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "2:59:59 Monday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 26, 2, 59, 59, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "6:01PM Thursday",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Monday,
+			endDay:          time.Thursday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 29, 18, 0, 1, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "2AM Saturday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 24, 2, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "2AM Wednesday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 28, 2, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "3AM Thursday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 22, 3, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "6PM Monday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 26, 18, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "2:59AM Thursday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 22, 2, 59, 59, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "6:01PM Monday, inverted days",
+			startTime:       NewTimeOfDay(3, 0, 0),
+			endTime:         NewTimeOfDay(18, 0, 0),
+			startDay:        time.Thursday,
+			endDay:          time.Monday,
+			location:        time.UTC,
+			now:             time.Date(2004, time.July, 26, 18, 0, 1, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "8:59AM Sunday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 8, 59, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "8:59:01AM Sunday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 8, 59, 1, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "9:01AM Sunday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "9AM Sunday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 9, 0, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+		{
+			label:           "8:59AM Monday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 4, 8, 59, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "8:59:01AM Monday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 4, 8, 59, 1, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "9:01AM Monday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 4, 9, 1, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "9AM Monday, whole week",
+			startTime:       NewTimeOfDay(9, 1, 0),
+			endTime:         NewTimeOfDay(8, 59, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 4, 9, 0, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "8:59AM Sunday, whole week, inverted times",
+			startTime:       NewTimeOfDay(8, 59, 0),
+			endTime:         NewTimeOfDay(9, 1, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 8, 59, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "9:01AM Sunday, whole week, inverted times",
+			startTime:       NewTimeOfDay(8, 59, 0),
+			endTime:         NewTimeOfDay(9, 1, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+			expectedInRange: true,
+		},
+		{
+			label:           "8:59AM Monday, whole week, inverted times",
+			startTime:       NewTimeOfDay(8, 59, 0),
+			endTime:         NewTimeOfDay(9, 1, 0),
+			startDay:        time.Sunday,
+			endDay:          time.Sunday,
+			location:        time.UTC,
+			now:             time.Date(2006, time.December, 4, 8, 59, 0, 0, time.UTC),
+			expectedInRange: false,
+		},
+	}
 
-	startTime := NewTimeOfDay(3, 0, 0)
-	endTime := NewTimeOfDay(18, 0, 0)
-	startDay := time.Monday
-	endDay := time.Thursday
-
-	now := time.Date(2004, time.July, 28, 2, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 27, 18, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 26, 2, 59, 59, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 29, 18, 0, 1, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	startDay = time.Thursday
-	endDay = time.Monday
-
-	now = time.Date(2004, time.July, 24, 2, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 28, 2, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 22, 3, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 26, 18, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 22, 2, 59, 59, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2004, time.July, 26, 18, 0, 1, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	startTime = NewTimeOfDay(9, 1, 0)
-	endTime = NewTimeOfDay(8, 59, 0)
-	startDay = time.Sunday
-	endDay = time.Sunday
-
-	now = time.Date(2006, time.December, 3, 8, 59, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 3, 8, 59, 1, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-	now = time.Date(2006, time.December, 3, 9, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 4, 8, 59, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 4, 8, 59, 1, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 4, 9, 1, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 4, 9, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	startTime = NewTimeOfDay(8, 59, 0)
-	endTime = NewTimeOfDay(9, 1, 0)
-	startDay = time.Sunday
-	endDay = time.Sunday
-
-	now = time.Date(2006, time.December, 3, 8, 59, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
-
-	now = time.Date(2006, time.December, 4, 8, 59, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInRange(now))
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			timeRange, err := NewWeekRangeInLocation(tc.startTime, tc.endTime, tc.startDay, tc.endDay, tc.location)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedInRange, timeRange.IsInRange(tc.now))
+		})
+	}
 }
 
 func TestTimeRangeIsInSameRange(t *testing.T) {
+	testcases := []struct {
+		label    string
+		start    TimeOfDay
+		end      TimeOfDay
+		location *time.Location
+		weekdays []time.Weekday
+		examples []struct {
+			label    string
+			time1    time.Time
+			time2    time.Time
+			expected bool
+		}
+	}{
+		{
+			label:    "start time is less than end time",
+			start:    NewTimeOfDay(3, 0, 0),
+			end:      NewTimeOfDay(18, 0, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same time",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time2 in same session but greater",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time2 in same session but less",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time1 not in same session",
+					time1:    time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "time2 not in same session",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 2, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "time1 within time range but next day",
+					time1:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "time2 within time range but next day",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "with weekdays, start time is less than end time",
+			start:    NewTimeOfDay(3, 0, 0),
+			end:      NewTimeOfDay(18, 0, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{time.Monday, time.Tuesday, time.Wednesday},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same time within range",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "same time outside weekdays range",
+					time1:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "time2 in same session but greater within range",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time2 in same session but less within range",
+					time1:    time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time2 in same session but greater outside range",
+					time1:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 11, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "time2 in same session but less outside range",
+					time1:    time.Date(2016, time.August, 11, 10, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 11, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "start time is greater than end time",
+			start:    NewTimeOfDay(18, 0, 0),
+			end:      NewTimeOfDay(3, 0, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same session, same day",
+					time1:    time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 20, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "same session, time2 is in next day",
+					time1:    time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 2, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "same session, time1 is in next day",
+					time1:    time.Date(2016, time.August, 11, 2, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "time1 is 25 hours greater than time2",
+					time1:    time.Date(2016, time.August, 11, 21, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 20, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "start time is equal to end time",
+			start:    NewTimeOfDay(6, 0, 0),
+			end:      NewTimeOfDay(6, 0, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "times on different days",
+					time1:    time.Date(2016, time.January, 13, 19, 10, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.January, 14, 19, 6, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "in different time zone",
+			start:    NewTimeOfDay(0, 0, 0),
+			end:      NewTimeOfDay(2, 0, 0),
+			location: time.FixedZone("myzone", -60),
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same times in range",
+					time1:    time.Date(2016, time.August, 10, 0, 1, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 0, 1, 0, 0, time.UTC),
+					expected: true,
+				},
+			},
+		},
+		{
+			label:    "in different time zone, inverted start/end",
+			start:    NewTimeOfDay(2, 0, 0),
+			end:      NewTimeOfDay(0, 0, 0),
+			location: time.FixedZone("myzone", -60),
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same times in range",
+					time1:    time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC),
+					expected: true,
+				},
+			},
+		},
+		{
+			label:    "midnight to midnight session in time zone",
+			start:    NewTimeOfDay(0, 0, 0),
+			end:      NewTimeOfDay(0, 0, 0),
+			location: time.FixedZone("custom", -60),
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "different days UTC but same in fixed zone",
+					time1:    time.Date(2016, time.August, 10, 0, 0, 0, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 0, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "midnight to midnight session in UTC",
+			start:    NewTimeOfDay(0, 0, 0),
+			end:      NewTimeOfDay(0, 0, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "spanning midnight",
+					time1:    time.Date(2016, time.August, 10, 23, 59, 59, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 11, 0, 0, 0, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+		{
+			label:    "1:49 to 1:49 session",
+			start:    NewTimeOfDay(1, 49, 0),
+			end:      NewTimeOfDay(1, 49, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "edgecase 1",
+					time1:    time.Date(2016, time.August, 16, 1, 48, 21, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 16, 1, 49, 02, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "edgecase 2",
+					time1:    time.Date(2016, time.August, 16, 13, 48, 21, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 16, 13, 49, 02, 0, time.UTC),
+					expected: true,
+				},
+			},
+		},
+		{
+			label:    "13:49 to 13:49 session",
+			start:    NewTimeOfDay(13, 49, 0),
+			end:      NewTimeOfDay(13, 49, 0),
+			location: time.UTC,
+			weekdays: []time.Weekday{},
+			examples: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "edgecase 1",
+					time1:    time.Date(2016, time.August, 16, 13, 48, 21, 0, time.UTC),
+					time2:    time.Date(2016, time.August, 16, 13, 49, 02, 0, time.UTC),
+					expected: false,
+				},
+			},
+		},
+	}
 
-	// start time is less than end time
-	start := NewTimeOfDay(3, 0, 0)
-	end := NewTimeOfDay(18, 0, 0)
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			var timeRange *TimeRange
+			var err error
 
-	// same time
-	time1 := time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-	time2 := time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
+			if tc.location == time.UTC {
+				timeRange, err = NewUTCTimeRange(tc.start, tc.end, tc.weekdays)
+			} else {
+				timeRange, err = NewTimeRangeInLocation(tc.start, tc.end, tc.weekdays, tc.location)
+			}
+			assert.Nil(t, err)
 
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-	// time 2 in same session but greater
-	time1 = time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC)
+			for _, example := range tc.examples {
+				t.Run(example.label, func(t *testing.T) {
+					assert.Equal(t, example.expected, timeRange.IsInSameRange(example.time1, example.time2))
+					assert.Equal(t, example.expected, timeRange.IsInSameRange(example.time2, example.time1))
+				})
+			}
+		})
+	}
 
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// time 2 in same session but less
-	time1 = time.Date(2016, time.August, 10, 11, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// time 1 not in session
-	time1 = time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// time 2 not in session
-	time1 = time.Date(2016, time.August, 10, 10, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 2, 0, 0, 0, time.UTC)
-
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// start time is greater than end time
-	start = NewTimeOfDay(18, 0, 0)
-	end = NewTimeOfDay(3, 0, 0)
-
-	// same session same day
-	time1 = time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 20, 0, 0, 0, time.UTC)
-
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// same session time 2 is in next day
-	time1 = time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 11, 2, 0, 0, 0, time.UTC)
-
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// same session time 1 is in next day
-	time1 = time.Date(2016, time.August, 11, 2, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 19, 0, 0, 0, time.UTC)
-
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// time 1 is 25 hours greater (han time 2
-	time1 = time.Date(2016, time.August, 11, 21, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 20, 0, 0, 0, time.UTC)
-
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	// start time is greater than end time
-	start = NewTimeOfDay(6, 0, 0)
-	end = NewTimeOfDay(6, 0, 0)
-
-	time1 = time.Date(2016, time.January, 13, 19, 10, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.January, 14, 19, 6, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	start = NewTimeOfDay(0, 0, 0)
-	end = NewTimeOfDay(2, 0, 0)
-	loc := time.FixedZone("myzone", -60)
-
-	time1 = time.Date(2016, time.August, 10, 0, 1, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 0, 1, 0, 0, time.UTC)
-	assert.True(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time1, time2))
-	assert.True(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time2, time1))
-
-	start = NewTimeOfDay(2, 0, 0)
-	end = NewTimeOfDay(0, 0, 0)
-	time1 = time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC)
-	assert.True(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time1, time2))
-	assert.True(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time2, time1))
-
-	var tr *TimeRange
-	assert.True(t, tr.IsInSameRange(time1, time2), "always in same range if time range is nil")
-
-	start = NewTimeOfDay(0, 0, 0)
-	end = NewTimeOfDay(0, 0, 0)
-	time1 = time.Date(2016, time.August, 10, 0, 0, 0, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 11, 0, 0, 0, 0, time.UTC)
-	assert.False(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time1, time2))
-	assert.False(t, NewTimeRangeInLocation(start, end, loc).IsInSameRange(time2, time1))
-
-	time1 = time.Date(2016, time.August, 10, 23, 59, 59, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 11, 0, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	start = NewTimeOfDay(1, 49, 0)
-	end = NewTimeOfDay(1, 49, 0)
-	time1 = time.Date(2016, time.August, 16, 1, 48, 21, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 16, 1, 49, 02, 0, time.UTC)
-
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	start = NewTimeOfDay(1, 49, 0)
-	end = NewTimeOfDay(1, 49, 0)
-	time1 = time.Date(2016, time.August, 16, 13, 48, 21, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 16, 13, 49, 02, 0, time.UTC)
-
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.True(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
-
-	start = NewTimeOfDay(13, 49, 0)
-	end = NewTimeOfDay(13, 49, 0)
-	time1 = time.Date(2016, time.August, 16, 13, 48, 21, 0, time.UTC)
-	time2 = time.Date(2016, time.August, 16, 13, 49, 02, 0, time.UTC)
-
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time1, time2))
-	assert.False(t, NewUTCTimeRange(start, end).IsInSameRange(time2, time1))
 }
 
 func TestTimeRangeIsInSameRangeWithDay(t *testing.T) {
+	testcases := []struct {
+		label     string
+		startTime TimeOfDay
+		endTime   TimeOfDay
+		startDay  time.Weekday
+		endDay    time.Weekday
+		location  *time.Location
+		cases     []struct {
+			label    string
+			time1    time.Time
+			time2    time.Time
+			expected bool
+		}
+	}{
+		{
+			label:     "base example",
+			startTime: NewTimeOfDay(3, 0, 0),
+			endTime:   NewTimeOfDay(18, 0, 0),
+			startDay:  time.Monday,
+			endDay:    time.Thursday,
+			location:  time.UTC,
+			cases: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "time1 before day range",
+					time1:    time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC), // Tuesday
+					time2:    time.Date(2004, time.July, 25, 3, 0, 0, 0, time.UTC), // Sunday
+					expected: false,
+				},
+				{
+					label:    "time1 after day range",
+					time1:    time.Date(2004, time.July, 31, 3, 0, 0, 0, time.UTC), // Saturday
+					time2:    time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC), // Tuesday
+					expected: false,
+				},
+				{
+					label:    "same date/time",
+					time1:    time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC), // Tuesday
+					time2:    time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC), // Tuesday
+					expected: true,
+				},
+				{
+					label:    "different days within day range",
+					time1:    time.Date(2004, time.July, 26, 10, 0, 0, 0, time.UTC), // Monday
+					time2:    time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC),  // Tuesday
+					expected: true,
+				},
+				{
+					label:    "different days within day range 2",
+					time1:    time.Date(2004, time.July, 27, 10, 0, 0, 0, time.UTC), // Tuesday
+					time2:    time.Date(2004, time.July, 29, 2, 0, 0, 0, time.UTC),  // Thursday
+					expected: true,
+				},
+				{
+					label:    "same day, different weeks",
+					time1:    time.Date(2004, time.July, 27, 10, 0, 0, 0, time.UTC), // Tuesday
+					time2:    time.Date(2004, time.July, 20, 3, 0, 0, 0, time.UTC),  // Tuesday
+					expected: false,
+				},
+				{
+					label:    "same day, different weeks inverted",
+					time1:    time.Date(2004, time.July, 20, 3, 0, 0, 0, time.UTC),  // Tuesday
+					time2:    time.Date(2004, time.July, 27, 10, 0, 0, 0, time.UTC), // Tuesday
+					expected: false,
+				},
+				{
+					label:    "different weeks again",
+					time1:    time.Date(2004, time.July, 26, 2, 0, 0, 0, time.UTC), // Monday
+					time2:    time.Date(2004, time.July, 19, 3, 0, 0, 0, time.UTC), // Monday
+					expected: false,
+				},
+			},
+		},
+		{
+			label:     "start/end time within an hour of midnight, week long session",
+			startTime: NewTimeOfDay(0, 5, 0),
+			endTime:   NewTimeOfDay(23, 45, 0),
+			startDay:  time.Sunday,
+			endDay:    time.Saturday,
+			location:  time.UTC,
+			cases: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "check DST change is handled when missing an hour",
+					time1:    time.Date(2006, time.April, 4, 0, 0, 0, 0, time.UTC),
+					time2:    time.Date(2006, time.April, 3, 1, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "check DST change is handled when gaining an hour",
+					time1:    time.Date(2006, time.October, 30, 0, 0, 0, 0, time.UTC),
+					time2:    time.Date(2006, time.October, 31, 1, 0, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "works across year boundary",
+					time1:    time.Date(2006, time.December, 31, 10, 10, 10, 0, time.UTC),
+					time2:    time.Date(2007, time.January, 1, 10, 10, 10, 0, time.UTC),
+					expected: true,
+				},
+			},
+		},
+		{
+			label:     "when session days are the same",
+			startTime: NewTimeOfDay(9, 1, 0),
+			endTime:   NewTimeOfDay(8, 59, 0),
+			location:  time.UTC,
+			cases: []struct {
+				label    string
+				time1    time.Time
+				time2    time.Time
+				expected bool
+			}{
+				{
+					label:    "same time",
+					time1:    time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+					time2:    time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+					expected: true,
+				},
+				{
+					label:    "different week",
+					time1:    time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+					time2:    time.Date(2006, time.December, 10, 9, 1, 0, 0, time.UTC),
+					expected: false,
+				},
+				{
+					label:    "different day",
+					time1:    time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC),
+					time2:    time.Date(2006, time.December, 4, 9, 1, 0, 0, time.UTC),
+					expected: true,
+				},
+			},
+		},
+	}
 
-	startTime := NewTimeOfDay(3, 0, 0)
-	endTime := NewTimeOfDay(18, 0, 0)
-	startDay := time.Monday
-	endDay := time.Thursday
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			var timeRange *TimeRange
+			var err error
 
-	time1 := time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	time2 := time.Date(2004, time.July, 25, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
+			if tc.location == time.UTC {
+				timeRange, err = NewUTCWeekRange(tc.startTime, tc.endTime, tc.startDay, tc.endDay)
+			} else {
+				timeRange, err = NewWeekRangeInLocation(tc.startTime, tc.endTime, tc.startDay, tc.endDay, tc.location)
+			}
+			assert.Nil(t, err)
 
-	time1 = time.Date(2004, time.July, 31, 3, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
+			for _, c := range tc.cases {
+				t.Run(c.label, func(t *testing.T) {
+					assert.Equal(t, c.expected, timeRange.IsInSameRange(c.time1, c.time2))
+				})
+			}
+		})
+	}
+}
 
-	time1 = time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
+func TestTimeRangeIsInSameRangeWhenNil(t *testing.T) {
+	time1 := time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC)
+	time2 := time.Date(2016, time.August, 10, 2, 1, 0, 0, time.UTC)
 
-	time1 = time.Date(2004, time.July, 26, 10, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 27, 3, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time1 = time.Date(2004, time.July, 27, 10, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 29, 2, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time1 = time.Date(2004, time.July, 27, 10, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 20, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time1 = time.Date(2004, time.July, 27, 2, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 20, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time1 = time.Date(2004, time.July, 26, 2, 0, 0, 0, time.UTC)
-	time2 = time.Date(2004, time.July, 19, 3, 0, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	// Reset start/end time so that they fall within an hour of midnight
-	startTime = NewTimeOfDay(0, 5, 0)
-	endTime = NewTimeOfDay(23, 45, 0)
-
-	// Make it a week-long session
-	startDay = time.Sunday
-	endDay = time.Saturday
-
-	// Check that ST-->DST (Sunday is missing one hour) is handled
-	time1 = time.Date(2006, time.April, 4, 0, 0, 0, 0, time.UTC)
-	time2 = time.Date(2006, time.April, 3, 1, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	// Check that DST-->ST (Sunday has an extra hour) is handled
-	time1 = time.Date(2006, time.October, 30, 0, 0, 0, 0, time.UTC)
-	time2 = time.Date(2006, time.October, 31, 1, 0, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	// Check that everything works across a year boundary
-	time1 = time.Date(2006, time.December, 31, 10, 10, 10, 0, time.UTC)
-	time2 = time.Date(2007, time.January, 1, 10, 10, 10, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	// Session days are the same
-	startDay = time.Sunday
-	endDay = time.Sunday
-	startTime = NewTimeOfDay(9, 1, 0)
-	endTime = NewTimeOfDay(8, 59, 0)
-	time1 = time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC)
-	time2 = time.Date(2006, time.December, 3, 9, 1, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time2 = time.Date(2006, time.December, 10, 9, 1, 0, 0, time.UTC)
-	assert.False(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
-
-	time2 = time.Date(2006, time.December, 4, 9, 1, 0, 0, time.UTC)
-	assert.True(t, NewUTCWeekRange(startTime, endTime, startDay, endDay).IsInSameRange(time1, time2))
+	var tr *TimeRange
+	assert.True(t, tr.IsInSameRange(time1, time2), "always in same range if time range is nil")
 }

--- a/session_factory.go
+++ b/session_factory.go
@@ -3,6 +3,7 @@ package quickfix
 import (
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -46,7 +47,7 @@ type sessionFactory struct {
 	BuildInitiators bool
 }
 
-//Creates Session, associates with internal session registry
+// Creates Session, associates with internal session registry
 func (f sessionFactory) createSession(
 	sessionID SessionID, storeFactory MessageStoreFactory, settings *SessionSettings,
 	logFactory LogFactory, application Application,
@@ -244,8 +245,37 @@ func (f sessionFactory) newSession(
 		}
 
 		if !settings.HasSetting(config.StartDay) && !settings.HasSetting(config.EndDay) {
-			s.SessionTime = internal.NewTimeRangeInLocation(start, end, loc)
+			weekdays := []time.Weekday{}
+			if settings.HasSetting(config.Weekdays) {
+				var weekdaysStr string
+				if weekdaysStr, err = settings.Setting(config.Weekdays); err != nil {
+					return
+				}
+
+				dayStrs := strings.Split(weekdaysStr, ",")
+
+				for _, dayStr := range dayStrs {
+					day, ok := dayLookup[dayStr]
+					if !ok {
+						err = IncorrectFormatForSetting{Setting: config.Weekdays, Value: weekdaysStr}
+						return
+					}
+					weekdays = append(weekdays, day)
+				}
+			}
+
+			var sessionTime *internal.TimeRange
+			sessionTime, err = internal.NewTimeRangeInLocation(start, end, weekdays, loc)
+			if err != nil {
+				return
+			}
+			s.SessionTime = sessionTime
 		} else {
+			if settings.HasSetting(config.Weekdays) {
+				err = errors.New("Weekdays cannot be specified with StartDay/EndDay")
+				return
+			}
+
 			var startDayStr, endDayStr string
 			if startDayStr, err = settings.Setting(config.StartDay); err != nil {
 				return
@@ -272,7 +302,12 @@ func (f sessionFactory) newSession(
 				return
 			}
 
-			s.SessionTime = internal.NewWeekRangeInLocation(start, end, startDay, endDay, loc)
+			var sessionTime *internal.TimeRange
+			sessionTime, err = internal.NewWeekRangeInLocation(start, end, startDay, endDay, loc)
+			if err != nil {
+				return
+			}
+			s.SessionTime = sessionTime
 		}
 	}
 

--- a/session_factory_test.go
+++ b/session_factory_test.go
@@ -176,8 +176,9 @@ func (s *SessionFactorySuite) TestStartAndEndTime() {
 	s.Nil(err)
 	s.NotNil(session.SessionTime)
 
+	expectedRange, _ := internal.NewUTCTimeRange(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0), []time.Weekday{})
 	s.Equal(
-		*internal.NewUTCTimeRange(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0)),
+		*expectedRange,
 		*session.SessionTime,
 	)
 }
@@ -191,8 +192,41 @@ func (s *SessionFactorySuite) TestStartAndEndTimeAndTimeZone() {
 	s.Nil(err)
 	s.NotNil(session.SessionTime)
 
+	expectedRange, _ := internal.NewTimeRangeInLocation(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0), []time.Weekday{}, time.Local)
 	s.Equal(
-		*internal.NewTimeRangeInLocation(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0), time.Local),
+		*expectedRange,
+		*session.SessionTime,
+	)
+}
+
+func (s *SessionFactorySuite) TestStartAndEndTimeAndWeekdays() {
+	s.SessionSettings.Set(config.StartTime, "12:00:00")
+	s.SessionSettings.Set(config.EndTime, "14:00:00")
+	s.SessionSettings.Set(config.Weekdays, "Monday,Tuesday,Wednesday")
+	session, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.Nil(err)
+	s.NotNil(session.SessionTime)
+
+	expectedRange, _ := internal.NewUTCTimeRange(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0), []time.Weekday{time.Monday, time.Tuesday, time.Wednesday})
+	s.Equal(
+		*expectedRange,
+		*session.SessionTime,
+	)
+}
+
+func (s *SessionFactorySuite) TestStartAndEndTimeAndTimeZoneAndWeekdays() {
+	s.SessionSettings.Set(config.StartTime, "12:00:00")
+	s.SessionSettings.Set(config.EndTime, "14:00:00")
+	s.SessionSettings.Set(config.TimeZone, "Local")
+	s.SessionSettings.Set(config.Weekdays, "Mon,Tue")
+
+	session, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.Nil(err)
+	s.NotNil(session.SessionTime)
+
+	expectedRange, _ := internal.NewTimeRangeInLocation(internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0), []time.Weekday{time.Monday, time.Tuesday}, time.Local)
+	s.Equal(
+		*expectedRange,
 		*session.SessionTime,
 	)
 }
@@ -217,11 +251,13 @@ func (s *SessionFactorySuite) TestStartAndEndTimeAndStartAndEndDay() {
 		s.Nil(err)
 		s.NotNil(session.SessionTime)
 
+		expectedRange, _ := internal.NewUTCWeekRange(
+			internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0),
+			time.Sunday, time.Thursday,
+		)
+
 		s.Equal(
-			*internal.NewUTCWeekRange(
-				internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0),
-				time.Sunday, time.Thursday,
-			),
+			*expectedRange,
 			*session.SessionTime,
 		)
 	}
@@ -238,11 +274,13 @@ func (s *SessionFactorySuite) TestStartAndEndTimeAndStartAndEndDayAndTimeZone() 
 	s.Nil(err)
 	s.NotNil(session.SessionTime)
 
+	expectedRange, _ := internal.NewWeekRangeInLocation(
+		internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0),
+		time.Sunday, time.Thursday, time.Local,
+	)
+
 	s.Equal(
-		*internal.NewWeekRangeInLocation(
-			internal.NewTimeOfDay(12, 0, 0), internal.NewTimeOfDay(14, 0, 0),
-			time.Sunday, time.Thursday, time.Local,
-		),
+		*expectedRange,
 		*session.SessionTime,
 	)
 }
@@ -281,6 +319,46 @@ func (s *SessionFactorySuite) TestInvalidTimeZone() {
 	s.NotNil(err)
 }
 
+func (s *SessionFactorySuite) TestInvalidWeekdays() {
+	s.SessionSettings.Set(config.StartTime, "12:00:00")
+	s.SessionSettings.Set(config.EndTime, "14:00:00")
+
+	testcases := []struct {
+		label string
+		input string
+	}{
+		{
+			label: "invalid day value",
+			input: "Monday,Tuesday,not valid",
+		},
+		{
+			label: "invalid separator",
+			input: "Monday;Tuesday",
+		},
+		{
+			label: "whitespace",
+			input: "Monday, Tuesday",
+		},
+		{
+			label: "trailing comma",
+			input: "Monday,",
+		},
+		{
+			label: "empty value",
+			input: "Monday,,Tuesday",
+		},
+	}
+
+	for _, testcase := range testcases {
+		s.T().Run(testcase.label, func(t *testing.T) {
+			s.SessionSettings.Set(config.Weekdays, testcase.input)
+
+			_, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+			s.NotNil(err)
+		})
+	}
+}
+
 func (s *SessionFactorySuite) TestMissingStartOrEndDay() {
 	s.SessionSettings.Set(config.StartTime, "12:00:00")
 	s.SessionSettings.Set(config.EndTime, "14:00:00")
@@ -311,6 +389,17 @@ func (s *SessionFactorySuite) TestStartOrEndDayParseError() {
 	s.SessionSettings.Set(config.EndDay, "blah")
 
 	_, err = s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
+	s.NotNil(err)
+}
+
+func (s *SessionFactorySuite) TestStartEndDayWithWeekdaysError() {
+	s.SessionSettings.Set(config.StartTime, "12:00:00")
+	s.SessionSettings.Set(config.EndTime, "14:00:00")
+	s.SessionSettings.Set(config.StartDay, "Monday")
+	s.SessionSettings.Set(config.EndDay, "Wednesday")
+	s.SessionSettings.Set(config.Weekdays, "Monday,Tuesday,Wednesday")
+
+	_, err := s.newSession(s.SessionID, s.MessageStoreFactory, s.SessionSettings, s.LogFactory, s.App)
 	s.NotNil(err)
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -341,10 +341,14 @@ func (s *SessionSuite) TestCheckSessionTimeInRange() {
 		s.IncrNextSenderMsgSeqNum()
 		s.IncrNextTargetMsgSeqNum()
 
-		s.session.SessionTime = internal.NewUTCTimeRange(
+		sessionTime, err := internal.NewUTCTimeRange(
 			internal.NewTimeOfDay(now.Clock()),
 			internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
+			[]time.Weekday{},
 		)
+		s.Assert().Nil(err)
+
+		s.session.SessionTime = sessionTime
 
 		s.session.CheckSessionTime(s.session, now)
 		if test.after != nil {
@@ -388,10 +392,14 @@ func (s *SessionSuite) TestCheckSessionTimeNotInRange() {
 		s.IncrNextTargetMsgSeqNum()
 
 		now := time.Now().UTC()
-		s.session.SessionTime = internal.NewUTCTimeRange(
+		sessionTime, err := internal.NewUTCTimeRange(
 			internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
 			internal.NewTimeOfDay(now.Add(time.Duration(2)*time.Hour).Clock()),
+			[]time.Weekday{},
 		)
+		s.Assert().Nil(err)
+
+		s.session.SessionTime = sessionTime
 
 		if test.expectOnLogout {
 			s.MockApp.On("OnLogout")
@@ -442,10 +450,14 @@ func (s *SessionSuite) TestCheckSessionTimeInRangeButNotSameRangeAsStore() {
 		s.IncrNextTargetMsgSeqNum()
 
 		now := time.Now().UTC()
-		s.session.SessionTime = internal.NewUTCTimeRange(
+		sessionTime, err := internal.NewUTCTimeRange(
 			internal.NewTimeOfDay(now.Add(time.Duration(-1)*time.Hour).Clock()),
 			internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
+			[]time.Weekday{},
 		)
+		s.Assert().Nil(err)
+
+		s.session.SessionTime = sessionTime
 
 		if test.expectOnLogout {
 			s.MockApp.On("OnLogout")
@@ -491,10 +503,14 @@ func (s *SessionSuite) TestIncomingNotInSessionTime() {
 		s.IncrNextTargetMsgSeqNum()
 
 		now := time.Now().UTC()
-		s.session.SessionTime = internal.NewUTCTimeRange(
+		sessionTime, err := internal.NewUTCTimeRange(
 			internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
 			internal.NewTimeOfDay(now.Add(time.Duration(2)*time.Hour).Clock()),
+			[]time.Weekday{},
 		)
+		s.Assert().Nil(err)
+
+		s.session.SessionTime = sessionTime
 		if test.expectOnLogout {
 			s.MockApp.On("OnLogout")
 		}
@@ -540,10 +556,14 @@ func (s *SessionSuite) TestSendAppMessagesNotInSessionTime() {
 		s.MockApp.AssertExpectations(s.T())
 
 		now := time.Now().UTC()
-		s.session.SessionTime = internal.NewUTCTimeRange(
+		sessionTime, err := internal.NewUTCTimeRange(
 			internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
 			internal.NewTimeOfDay(now.Add(time.Duration(2)*time.Hour).Clock()),
+			[]time.Weekday{},
 		)
+		s.Assert().Nil(err)
+
+		s.session.SessionTime = sessionTime
 		if test.expectOnLogout {
 			s.MockApp.On("OnLogout")
 		}
@@ -585,10 +605,14 @@ func (s *SessionSuite) TestTimeoutNotInSessionTime() {
 			s.IncrNextTargetMsgSeqNum()
 
 			now := time.Now().UTC()
-			s.session.SessionTime = internal.NewUTCTimeRange(
+			sessionTime, err := internal.NewUTCTimeRange(
 				internal.NewTimeOfDay(now.Add(time.Hour).Clock()),
 				internal.NewTimeOfDay(now.Add(time.Duration(2)*time.Hour).Clock()),
+				[]time.Weekday{},
 			)
+			s.Assert().Nil(err)
+
+			s.session.SessionTime = sessionTime
 			if test.expectOnLogout {
 				s.MockApp.On("OnLogout")
 			}


### PR DESCRIPTION
Hi there, I should have opened an issue to discuss, but we had another requirement for a FIX integration we have just started running in production with a large exchange, and this is our first pass at solving this, so I thought I'd submit upstream for feedback in case we've missed something.

The session we currently have with the exchange requires *daily* sessions but only during the week (Monday - Friday). We discovered when trying to define the session that including `StartDay/EndDay` properties in the session config made the session into a week long version so we wouldn't get the daily session end happening as required. To give this example again more concretely - with the following settings:

- StartTime: 08:00:00
- EndTime: 16:30:00
- StartDay: Monday
- EndDay: Friday

our session would start fine at 8am on Monday, but then at 4:30pm on Monday, the session would not logout, instead would stay connected right through until Friday at 4:30pm. 

In looking at the config options provided by QuickFIX/J (https://www.quickfixj.org/usermanual/2.3.0/usage/configuration.html) we noticed they also provide a config setting called `Weekdays` which takes a comma separated list of day values with the semantics:

> "For daily sessions that are active on specific days of the week."

this setting seemed to be exactly what we'd need, so this PR attempts to add this setting into QuickFIX/Go. We've updated tests I think correctly, though the tests in session_test.go were a little hard for us to follow, so it might be that we've missed something in there. We're in the process of testing out this branch on our side, so will convert this from a draft PR once we have some confidence on how it operates in practice.

Please note while making this change we also removed the panic inside TimeRange if given a nil location, and instead returned the error explicitly. This meant some minor changes in the parsing code in SessionFactory, and quite a few changes to tests, but we felt this change is more idiomatic for the situation where the nil location is something the caller could recover from by correcting the TimeZone value