### PR TITLE
Added log factory for zap.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,9 @@ require (
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -52,6 +53,12 @@ github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqTosly
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=
 go.mongodb.org/mongo-driver v1.11.1 h1:QP0znIRTuL0jf1oBQoAoM0C6ZJfBK4kx0Uumtv1A7w8=
 go.mongodb.org/mongo-driver v1.11.1/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/zap_log.go
+++ b/zap_log.go
@@ -6,8 +6,11 @@ import (
 )
 
 // ZAP logger for quickfix
-// Uses ZAP (https://pkg.go.dev/go.uber.org/zap), currently the lowest latency logger for golang
-// Supports screen logging, json logging and a fair amount of additional customization
+// Uses ZAP (https://pkg.go.dev/go.uber.org/zap), a very low latency logger for golang which supports
+//  - screen logging
+//  - json logging
+//  - caller details with line numbers (short and full path)
+//  - default configurations that give stack traces when appropriate in dev and production default configurations.
 // This wrapper is pretty straightforward passing the quickfix logging directly to zap at info level
 // It sets a named logger for each session with Prefix+Sender:Target as the label.
 // Setting prefix to "" results in the message being labeled with just the sender and target.
@@ -19,6 +22,19 @@ import (
 //   - Allow different log levels for messages and events
 //   - Pre-check info is enabled - which would save some formatting time if info is disabled (unlikely?)
 //   - Support split logging of events to ZAP and messages to a file
+// ---
+// Usage
+//   ...
+//   Initialize zap
+//   zapCfg := zap.NewDevelopmentConfig()
+//   zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder  // colourize levels
+//   Atom := zapCfg.Level   // use Atom to turn on/off log levels if you need to
+//   logger, _ := zapCfg.Build()
+//   zap.ReplaceGlobals(logger)
+//   ...
+//   logFactory := quickfix.NewZapLogFactory("FIX_", true)  // FIX_ prefix and message logging enabled
+//   acceptor, err := quickfix.NewAcceptor(app, messageStoreFactory, appSettings, logFactory)
+//   ...
 //
 
 type ZapLog struct {

--- a/zap_log.go
+++ b/zap_log.go
@@ -2,6 +2,7 @@ package quickfix
 
 import (
 	"bytes"
+
 	"go.uber.org/zap"
 )
 

--- a/zap_log.go
+++ b/zap_log.go
@@ -1,0 +1,90 @@
+package quickfix
+
+import (
+	"bytes"
+	"go.uber.org/zap"
+)
+
+// ZAP logger for quickfix
+// Uses ZAP (https://pkg.go.dev/go.uber.org/zap), currently the lowest latency logger for golang
+// Supports screen logging, json logging and a fair amount of additional customization
+// This wrapper is pretty straightforward passing the quickfix logging directly to zap at info level
+// It sets a named logger for each session with Prefix+Sender:Target as the label.
+// Setting prefix to "" results in the message being labeled with just the sender and target.
+// There is also an option to enable or disable detailed message logging.
+// If message logging is enabled, EOM field separators are replaced with | for readability.
+//
+// Possible future improvements:
+//   - Take advantage of ZAP field based logging to put the message body in its own json field
+//   - Allow different log levels for messages and events
+//   - Pre-check info is enabled - which would save some formatting time if info is disabled (unlikely?)
+//   - Support split logging of events to ZAP and messages to a file
+//
+
+type ZapLog struct {
+	logger      *zap.SugaredLogger
+	rawMessages bool
+	name        string
+}
+
+type ZapLogFactory struct {
+	prefix   string
+	messages bool
+}
+
+func (l ZapLog) OnIncoming(s []byte) {
+	if l.rawMessages {
+		sNew := ReplaceEos(s)
+		l.logger.Infof("incoming <-:  %s", sNew)
+	}
+}
+
+func (l ZapLog) OnOutgoing(s []byte) {
+	if l.rawMessages {
+		sNew := ReplaceEos(s)
+		l.logger.Infof("outgoing ->: %s", sNew)
+	}
+}
+
+func (l ZapLog) OnEvent(s string) {
+	l.logger.Infof("event:  %s", s)
+}
+
+func (l ZapLog) OnEventf(format string, a ...interface{}) {
+	l.logger.Infof(format, a...)
+}
+
+func (f ZapLogFactory) Create() (Log, error) {
+	name := f.prefix + "GLOBAL"
+	log := ZapLog{
+		name:        name,
+		logger:      zap.S().Named(name).WithOptions(zap.AddCallerSkip(1)),
+		rawMessages: f.messages,
+	}
+	return log, nil
+}
+
+func (f ZapLogFactory) CreateSessionLog(sessionID SessionID) (Log, error) {
+	name := f.prefix + sessionID.SenderCompID + ":" + sessionID.TargetCompID
+	log := ZapLog{
+		name:        name,
+		logger:      zap.S().Named(name).WithOptions(zap.AddCallerSkip(1)),
+		rawMessages: f.messages,
+	}
+	return log, nil
+}
+
+// NewZapLogFactory Factory for quickfix to use zap logging
+func NewZapLogFactory(prefix string, logMessages bool) ZapLogFactory {
+	return ZapLogFactory{
+		prefix:   prefix,
+		messages: logMessages,
+	}
+}
+
+// ReplaceEos
+// Format message for display, replace EOS (ascii 001) with |
+func ReplaceEos(s []byte) []byte {
+	sNew := bytes.Replace(s, []byte("\u0001"), []byte("|"), 9999)
+	return sNew
+}

--- a/zap_log_test.go
+++ b/zap_log_test.go
@@ -1,0 +1,50 @@
+package quickfix
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewZapLogFactory(t *testing.T) {
+	f := NewZapLogFactory("pre", true)
+	assert.Equal(t, "pre", f.prefix)
+	assert.True(t, f.messages)
+}
+
+func TestReplaceEos(t *testing.T) {
+	var preFormat, postFormat []byte
+	preFormat = []byte("8=FIXT.1.1\u00019=74\u000135=CW\u000134=114\u000149=MIXFI\u000152=20221227-13:51:21.209\u000156=SELL1\u0001117=ID09876\u0001297=0\u000110=078\u0001")
+	postFormat = []byte("8=FIXT.1.1|9=74|35=CW|34=114|49=MIXFI|52=20221227-13:51:21.209|56=SELL1|117=ID09876|297=0|10=078|")
+
+	res := ReplaceEos(preFormat)
+	assert.Equal(t, postFormat, res)
+}
+
+func TestZapLogFactory_Create(t *testing.T) {
+	f := NewZapLogFactory("fix ", false)
+	l, err := f.Create()
+	assert.Nil(t, err, "no error from Create()")
+	zl, ok := l.(ZapLog)
+	assert.True(t, ok, "logger is of type ZapLog")
+	assert.Equal(t, "fix GLOBAL", zl.name, "logger name")
+}
+
+func TestZapLogFactory_CreateSessionLog(t *testing.T) {
+
+	f := NewZapLogFactory("", false)
+	sessionId := SessionID{
+		BeginString:      "",
+		TargetCompID:     "TOCOMP",
+		TargetSubID:      "",
+		TargetLocationID: "",
+		SenderCompID:     "FROMCOMP",
+		SenderSubID:      "",
+		SenderLocationID: "",
+		Qualifier:        "",
+	}
+	l, err := f.CreateSessionLog(sessionId)
+	assert.Nil(t, err, "no error from Create()")
+	zl, ok := l.(ZapLog)
+	assert.True(t, ok, "logger is of type ZapLog")
+	assert.Equal(t, "FROMCOMP:TOCOMP", zl.name, "logger name")
+}

--- a/zap_log_test.go
+++ b/zap_log_test.go
@@ -21,18 +21,18 @@ func TestReplaceEos(t *testing.T) {
 }
 
 func TestZapLogFactory_Create(t *testing.T) {
-	f := NewZapLogFactory("fix ", false)
+	f := NewZapLogFactory("FIX_", false)
 	l, err := f.Create()
 	assert.Nil(t, err, "no error from Create()")
 	zl, ok := l.(ZapLog)
 	assert.True(t, ok, "logger is of type ZapLog")
-	assert.Equal(t, "fix GLOBAL", zl.name, "logger name")
+	assert.Equal(t, "FIX_GLOBAL", zl.name, "logger name")
 }
 
 func TestZapLogFactory_CreateSessionLog(t *testing.T) {
 
 	f := NewZapLogFactory("", false)
-	sessionId := SessionID{
+	sessionID := SessionID{
 		BeginString:      "",
 		TargetCompID:     "TOCOMP",
 		TargetSubID:      "",
@@ -42,7 +42,7 @@ func TestZapLogFactory_CreateSessionLog(t *testing.T) {
 		SenderLocationID: "",
 		Qualifier:        "",
 	}
-	l, err := f.CreateSessionLog(sessionId)
+	l, err := f.CreateSessionLog(sessionID)
 	assert.Nil(t, err, "no error from Create()")
 	zl, ok := l.(ZapLog)
 	assert.True(t, ok, "logger is of type ZapLog")

--- a/zap_log_test.go
+++ b/zap_log_test.go
@@ -1,8 +1,9 @@
 package quickfix
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewZapLogFactory(t *testing.T) {


### PR DESCRIPTION
ZAP logger for quickfix

To use:
```golang
...
// Initialize zap
zapCfg := zap.NewDevelopmentConfig()
zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder  // colourize levels
Atom := zapCfg.Level   // use Atom to turn on/off log levels if you need to
logger, _ := zapCfg.Build()
zap.ReplaceGlobals(logger)
...
logFactory := quickfix.NewZapLogFactory("FIX_", true)  // FIX_ prefix and message logging enabled
acceptor, err := quickfix.NewAcceptor(app, messageStoreFactory, appSettings, logFactory)
...
```

Uses ZAP (https://pkg.go.dev/go.uber.org/zap), a very low latency logger for golang which supports:
* screen logging
* json logging
* caller details with line numbers (short and full path)
* default configurations that give stack traces when appropropriate in dev and production default configurations.   

This wrapper passes all the quickfix logging directly to zap at `INFO` level.

It sets a named logger for each session with `Prefix+Sender:Target` as the label.
Setting prefix to `""` results in the message being labeled with just the sender and target.

For example if the Sender is `SEND` and the target is `TARG` and the prefix is `FIX_` then the name will be `FIX_SEND:TARG`.

There is also an option to enable or disable detailed message logging.
If message logging is enabled, `EOM` field separators are replaced with `|` for readability.

With no prefix you will see log messages similar to this using console/debug logging.
```
2022-12-28T00:59:05.023Z        INFO    FROMCOMP:TOCOMP     quickfix@v0.6.1/session_state.go:69       incoming <-:  8=FIXT.1.1|9=76|35=CW|34=32|49=TOCOMP|52=20221228-00:59:05.022921|56=FROMCOMP|117=ID09876|297=0|10=187|
```

And with json logging
```
{"level":"info","ts":1672189226.004965,"logger":"FROMCOMP:TOCOMP","caller":"quickfix@v0.6.1/session.go:355","msg":"outgoing ->: 8=FIXT.1.1|9=81|35=A|34=1|49=FROMCOMP|52=20221228-01:00:26.004921|56=TOCOMP|98=0|108=30|141=Y|1137=9|10=039|"}

```

Tests have been added.  Unfortunately without completely mocking the logger it is difficult to test the actual logging functions, but as they are passthroughs to ZAP there are unlikely to be any regression errors in this factory and logger.

----

Possible future improvements:
- Take advantage of ZAP field based logging to put the message body in its own json field
- Allow different log levels for messages and events
- Pre-check info is enabled - which would save some formatting time if info is disabled (unlikely?)
- Support split logging of events to ZAP and messages to a file
