### PR TITLE
Remove tag from field map

### DIFF
--- a/field_map.go
+++ b/field_map.go
@@ -227,6 +227,14 @@ func (m *FieldMap) SetString(tag Tag, value string) *FieldMap {
 	return m.SetBytes(tag, []byte(value))
 }
 
+// Remove removes a tag from field map
+func (m *FieldMap) Remove(tag Tag) {
+	m.rwLock.Lock()
+	defer m.rwLock.Unlock()
+
+	delete(m.tagLookup, tag)
+}
+
 // Clear purges all fields from field map.
 func (m *FieldMap) Clear() {
 	m.rwLock.Lock()

--- a/field_map.go
+++ b/field_map.go
@@ -227,7 +227,7 @@ func (m *FieldMap) SetString(tag Tag, value string) *FieldMap {
 	return m.SetBytes(tag, []byte(value))
 }
 
-// Remove removes a tag from field map
+// Remove removes a tag from field map.
 func (m *FieldMap) Remove(tag Tag) {
 	m.rwLock.Lock()
 	defer m.rwLock.Unlock()

--- a/field_map_test.go
+++ b/field_map_test.go
@@ -190,3 +190,15 @@ func TestFieldMap_CopyInto(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "a", s)
 }
+
+func TestFieldMap_Remove(t *testing.T) {
+	var fMap FieldMap
+	fMap.init()
+
+	fMap.SetField(1, FIXString("hello"))
+	fMap.SetField(2, FIXString("world"))
+
+	fMap.Remove(1)
+	assert.False(t, fMap.Has(1))
+	assert.True(t, fMap.Has(2))
+}


### PR DESCRIPTION
Remove the specific tag from the FIX message. This is helpful when dealing with clients not following FIX specifications strictly