### PR TITLE
Add message.Bytes() to avoid string conversion

### DIFF
--- a/message.go
+++ b/message.go
@@ -272,7 +272,6 @@ func ParseMessageWithDataDictionary(
 	}
 
 	return
-
 }
 
 func isHeaderField(tag Tag, dataDict *datadictionary.DataDictionary) bool {
@@ -388,6 +387,14 @@ func extractField(parsedFieldBytes *TagValue, buffer []byte) (remBytes []byte, e
 
 	err = parsedFieldBytes.parse(buffer[:endIndex+1])
 	return buffer[(endIndex + 1):], err
+}
+
+func (m *Message) Bytes() []byte {
+	if m.rawMessage != nil {
+		return m.rawMessage.Bytes()
+	}
+
+	return m.build()
 }
 
 func (m *Message) String() string {

--- a/message_test.go
+++ b/message_test.go
@@ -222,12 +222,14 @@ func (s *MessageSuite) TestCopyIntoMessage() {
 	s.Nil(ParseMessage(s.msg, bytes.NewBufferString(newMsgString)))
 	s.True(s.msg.IsMsgTypeOf("A"))
 	s.Equal(s.msg.String(), newMsgString)
+	s.Equal(string(s.msg.Bytes()), newMsgString)
 
 	// clear the source buffer also
 	msgBuf.Reset()
 
 	s.True(dest.IsMsgTypeOf("D"))
 	s.Equal(dest.String(), renderedString)
+	s.Equal(string(dest.Bytes()), renderedString)
 }
 
 func checkFieldInt(s *MessageSuite, fields FieldMap, tag, expected int) {


### PR DESCRIPTION
Add `message.Bytes()` method as an alternative to `message.String()` to avoid the string conversion in case you need to use the raw bytes.