### PR TITLE
Add message batch sending

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -64,6 +64,21 @@ func SendToTarget(m Messagable, sessionID SessionID) error {
 	return session.queueForSend(msg)
 }
 
+// SendBatchToTarget sends a batch of messages based on the sessionID. This allows for better mutex contention if we're sending large batches of messages repeatedly.
+func SendBatchToTarget(messages []Messagable, sessionID SessionID) error {
+	session, ok := lookupSession(sessionID)
+	if !ok {
+		return errUnknownSession
+	}
+	msgs := make([]*Message, 0, len(messages))
+	for _, m := range messages {
+		msg := m.ToMessage()
+		msgs = append(msgs, msg)
+	}
+
+	return session.queueBatchForSend(msgs)
+}
+
 // ResetSession resets session's sequence numbers.
 func ResetSession(sessionID SessionID) error {
 	session, ok := lookupSession(sessionID)

--- a/session_test.go
+++ b/session_test.go
@@ -821,6 +821,17 @@ func (suite *SessionSendTestSuite) TestQueueForSendAppMessage() {
 	suite.NextSenderMsgSeqNum(2)
 }
 
+func (suite *SessionSendTestSuite) TestQueueBatchForSendAppMessage() {
+	suite.MockApp.On("ToApp").Return(nil)
+	require.Nil(suite.T(), suite.queueBatchForSend([]*Message{suite.NewOrderSingle(), suite.NewOrderSingle(), suite.NewOrderSingle()}))
+
+	suite.MockApp.AssertExpectations(suite.T())
+	suite.NoMessageSent()
+	suite.MessagePersisted(suite.MockApp.lastToApp)
+	suite.FieldEquals(tagMsgSeqNum, 3, suite.MockApp.lastToApp.Header)
+	suite.NextSenderMsgSeqNum(4)
+}
+
 func (suite *SessionSendTestSuite) TestQueueForSendDoNotSendAppMessage() {
 	suite.MockApp.On("ToApp").Return(ErrDoNotSend)
 	suite.Equal(ErrDoNotSend, suite.queueForSend(suite.NewOrderSingle()))


### PR DESCRIPTION
## Description

- When queueing fix messages for sending, moved the notification channel sending to be out of the lock, this caused unneeded lock contention as the thread receiving for the channel was locking the same locking after receiving the message.
- Added a method to send a batch of messages to the queue, which allows to reduce lock contention even more.