### PR TITLE
Group field whose elements do not have the same fields are incorrectly parsed

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -246,7 +246,6 @@ func validateVisitGroupField(fieldDef *datadictionary.FieldDef, fieldStack []Tag
 			if childDefs[0].Required() {
 				return fieldStack, RequiredTagMissing(Tag(childDefs[0].Tag()))
 			}
-			fieldStack = fieldStack[1:]
 		}
 
 		childDefs = childDefs[1:]

--- a/validation_test.go
+++ b/validation_test.go
@@ -74,6 +74,7 @@ func TestValidate(t *testing.T) {
 		tcInvalidTagCheckDisabledFixT(),
 		tcInvalidTagCheckEnabled(),
 		tcInvalidTagCheckEnabledFixT(),
+		tcMultipleRepeatingGroupFields(),
 	}
 
 	msg := NewMessage()
@@ -920,6 +921,17 @@ func tcFloatValidationFixT() validateTest {
 		MessageBytes:         []byte("8=FIXT.1.19=10635=D34=249=TW52=20140329-22:38:4556=ISLD11=ID21=140=154=138=+200.0055=INTC60=20140329-22:38:4510=178"),
 		ExpectedRejectReason: rejectReasonIncorrectDataFormatForValue,
 		ExpectedRefTagID:     &tag,
+	}
+}
+
+func tcMultipleRepeatingGroupFields() validateTest {
+	dict, _ := datadictionary.Parse("spec/FIX43.xml")
+	validator := NewValidator(defaultValidatorSettings, dict, nil)
+	return validateTest{
+		TestName:             "Multiple repeating group fields in a message",
+		Validator:            validator,
+		MessageBytes:         []byte("8=FIX.4.39=17635=D34=249=TW52=20140329-22:38:4556=ISLD11=ID453=2448=PARTYID452=3523=SUBID448=PARTYID2452=378=179=ACCOUNT80=121=140=154=138=20055=INTC60=20140329-22:38:4510=178"),
+		DoNotExpectReject:    true,
 	}
 }
 


### PR DESCRIPTION
The edge case is described in the unit test added in this PR

When a group field contains more than one element and one of the elements has less params (because they are optional), it will be parsed incorrectly due to the change added in #368

e.g.
```
453=2448=PARTYID452=3523=SUBID448=PARTYID2452=3
```

in the example, the last element does not have _523_ defined

this means that a fix for #365 / #366 is still required