### PR TITLE
Do not increment NextTargetMsgSeqNum for out of sequence Logout and Test Requests

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -102,14 +102,23 @@ func (state inSession) handleLogout(session *session, msg *Message) (nextState s
 		session.log.OnEvent("Received logout response")
 	}
 
-	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {
-		session.logError(err)
-	}
-
 	if session.ResetOnLogout {
 		if err := session.dropAndReset(); err != nil {
 			session.logError(err)
 		}
+		return latentState{}
+	}
+
+	if err := session.checkTargetTooLow(msg); err != nil {
+		return latentState{}
+	}
+
+	if err := session.checkTargetTooHigh(msg); err != nil {
+		return latentState{}
+	}
+
+	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {
+		session.logError(err)
 	}
 
 	return latentState{}
@@ -129,6 +138,14 @@ func (state inSession) handleTestRequest(session *session, msg *Message) (nextSt
 		if err := session.sendInReplyTo(heartBt, msg); err != nil {
 			return handleStateError(session, err)
 		}
+	}
+
+	if err := session.checkTargetTooLow(msg); err != nil {
+		return state
+	}
+
+	if err := session.checkTargetTooHigh(msg); err != nil {
+		return state
 	}
 
 	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {

--- a/in_session.go
+++ b/in_session.go
@@ -140,14 +140,6 @@ func (state inSession) handleTestRequest(session *session, msg *Message) (nextSt
 		}
 	}
 
-	if err := session.checkTargetTooLow(msg); err != nil {
-		return state
-	}
-
-	if err := session.checkTargetTooHigh(msg); err != nil {
-		return state
-	}
-
 	if err := session.store.IncrNextTargetMsgSeqNum(); err != nil {
 		return handleStateError(session, err)
 	}

--- a/in_session_test.go
+++ b/in_session_test.go
@@ -96,6 +96,23 @@ func (s *InSessionTestSuite) TestLogoutResetOnLogout() {
 	s.NoMessageQueued()
 }
 
+func (s *InSessionTestSuite) TestLogoutTargetTooHigh() {
+	s.MessageFactory.seqNum = 5
+
+	s.MockApp.On("FromAdmin").Return(nil)
+	s.MockApp.On("ToAdmin")
+	s.MockApp.On("OnLogout")
+	s.session.fixMsgIn(s.session, s.Logout())
+
+	s.MockApp.AssertExpectations(s.T())
+	s.State(latentState{})
+
+	s.LastToAdminMessageSent()
+	s.MessageType(string(msgTypeLogout), s.MockApp.lastToAdmin)
+	s.NextTargetMsgSeqNum(1)
+	s.NextSenderMsgSeqNum(2)
+}
+
 func (s *InSessionTestSuite) TestTimeoutNeedHeartbeat() {
 	s.MockApp.On("ToAdmin").Return(nil)
 	s.session.Timeout(s.session, internal.NeedHeartbeat)


### PR DESCRIPTION
If an out-of-sequence Logout or Test Request is received, either during `inSession` or `resendState`, it should not result in incrementing the next expected target sequence number, or else we have a chance of missing a message.

Consider the scenario below from the point of view of an Initiator.
We receive a Logout request from Acceptor:
```
FIX incoming [FIX.4.2:SENDER->TARGET |8=FIX.4.2|35=5|34=100|
FIX event [FIX.4.2:SENDER->TARGET - Received logout request]
FIX event [FIX.4.2:SENDER->TARGET - Sending logout response]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=5|34=10|
FIX event [FIX.4.2:SENDER->TARGET - Disconnected]
```

After some time we try to Logon again:
```
FIX event [FIX.4.2:SENDER->TARGET - Sending logon request]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=A|34=11|
FIX incoming [FIX.4.2:SENDER->TARGET |8=FIX.4.2|35=A|34=105|
FIX event [FIX.4.2:SENDER->TARGET - Received logon response]
FIX event [FIX.4.2:SENDER->TARGET - MsgSeqNum too high, expecting 101 but received 105]
FIX event [FIX.4.2:SENDER->TARGET - Sent ResendRequest FROM: 101 TO: 0]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=2|34=12|7=101|16=0|
```

But we receive another Logout request from Acceptor:
```
FIX incoming [FIX.4.2:SENDER->TARGET |8=FIX.4.2|35=5|34=106|
FIX event [FIX.4.2:SENDER->TARGET - Received logout request]
FIX event [FIX.4.2:SENDER->TARGET - Sending logout response]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=5|34=13|
FIX event [FIX.4.2:SENDER->TARGET - Disconnected]
```

However, this out-of-sequence Logout request received from the Acceptor increments the next expected target sequence number from 101 to 102. Hence, when we try to Logon again:
```
FIX event [FIX.4.2:SENDER->TARGET - Sending logon request]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=A|34=14|
FIX incoming [FIX.4.2:SENDER->TARGET |8=FIX.4.2|35=A|34=107|
FIX event [FIX.4.2:SENDER->TARGET - Received logon response]
FIX event [FIX.4.2:SENDER->TARGET - MsgSeqNum too high, expecting 102 but received 107]
FIX event [FIX.4.2:SENDER->TARGET - Sent ResendRequest FROM: 102 TO: 0]
FIX outgoing [FIX.4.2:SENDER->TARGET - |8=FIX.4.2|35=2|34=15|7=102|16=0|
```

Therefore, we have now permanently skipped asking for a resend of sequence number 101, even though we never received it. This will result in us missing sequence number 101 from the Acceptor.

This PR addresses this issue for out-of-sequence Logout Requests as well as for Test Requests which seem to have the same problem.