### PR TITLE
Support TLS configuration as raw bytes

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -739,6 +739,47 @@ const (
 	//  - A filepath to a file with read access.
 	SocketCAFile string = "SocketCAFile"
 
+	// SocketPrivateKeyBytes is an optional value containing raw bytes of a PEM
+	// encoded private key to use for secure TLS communications.
+	// Must be used with SocketCertificateBytes.
+	// Must contain PEM encoded data.
+	//
+	// Required: No
+	//
+	// Default: N/A
+	//
+	// Valid Values:
+	//  - Raw bytes containing a valid PEM encoded private key.
+	SocketPrivateKeyBytes string = "SocketPrivateKeyBytes"
+
+	// SocketCertificateBytes is an optional value containing raw bytes of a PEM
+	// encoded certificate to use for secure TLS communications.
+	// Must be used with SocketPrivateKeyBytes.
+	// Must contain PEM encoded data.
+	//
+	// Required: No
+	//
+	// Default: N/A
+	//
+	// Valid Values:
+	//  - Raw bytes containing a valid PEM encoded certificate.
+	SocketCertificateBytes string = "SocketCertificateBytes"
+
+	// SocketCABytes is an optional value containing raw bytes of a PEM encoded
+	// root CA to use for secure TLS communications. For acceptors, client
+	// certificates will be verified against this CA. For initiators, clients
+	// will use the CA to verify the server certificate. If not configured,
+	// initiators will verify the server certificates using the host's root CA
+	// set.
+	//
+	// Required: No
+	//
+	// Default: N/A
+	//
+	// Valid Values:
+	//  - Raw bytes containing a valid PEM encoded CA.
+	SocketCABytes string = "SocketCABytes"
+
 	// SocketInsecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
 	// If SocketInsecureSkipVerify is set to Y, crypto/tls accepts any certificate presented by the server and any host name in that certificate.
 	// In this mode, TLS is susceptible to machine-in-the-middle attacks unless custom verification is used.

--- a/session_factory.go
+++ b/session_factory.go
@@ -284,7 +284,7 @@ func (f sessionFactory) newSession(
 				for _, dayStr := range dayStrs {
 					day, ok := dayLookup[dayStr]
 					if !ok {
-						err = IncorrectFormatForSetting{Setting: config.Weekdays, Value: weekdaysStr}
+						err = IncorrectFormatForSetting{Setting: config.Weekdays, Value: []byte(weekdaysStr)}
 						return
 					}
 					weekdays = append(weekdays, day)
@@ -315,7 +315,7 @@ func (f sessionFactory) newSession(
 			parseDay := func(setting, dayStr string) (day time.Weekday, err error) {
 				day, ok := dayLookup[dayStr]
 				if !ok {
-					return day, IncorrectFormatForSetting{Setting: setting, Value: dayStr}
+					return day, IncorrectFormatForSetting{Setting: setting, Value: []byte(dayStr)}
 				}
 				return
 			}
@@ -355,7 +355,7 @@ func (f sessionFactory) newSession(
 			s.timestampPrecision = Nanos
 
 		default:
-			err = IncorrectFormatForSetting{Setting: config.TimeStampPrecision, Value: precisionStr}
+			err = IncorrectFormatForSetting{Setting: config.TimeStampPrecision, Value: []byte(precisionStr)}
 			return
 		}
 	}


### PR DESCRIPTION
This change is intended to allow users to configure TLS settings in the form of raw byte slices. This is particularly useful for situations where the FIX application is running in a cloud environment (e.g. k8s) and session configuration is loaded from a database (rather than a static file). In this scenario it is much more convenient to be able to load TLS key pairs from the DB in the form of byte slices, than it is to have to ensure files with the correct names exist on some persistent volume such that the FIX app can load them from disk correctly.

To support this we changed the basic type stored within SessionSettings to be a byte slice which means we are able to still support the existing settings model, but also handle raw byte slices we can use for TLS setup. The existing API exposed by SessionSettings remains unchanged meaning users should not have to update their codee, but we have added a new `SetRaw` and `RawSetting` accessors to directly read/write byte slice values.