### PR TITLE
Use bytes.Count to count the number of message fields

### DIFF
--- a/message.go
+++ b/message.go
@@ -187,12 +187,7 @@ func doParsing(mp *msgParser) (err error) {
 	mp.msg.Trailer.Clear()
 
 	// Allocate expected message fields in one chunk.
-	fieldCount := 0
-	for _, b := range mp.rawBytes {
-		if b == '\001' {
-			fieldCount++
-		}
-	}
+	fieldCount := bytes.Count(mp.rawBytes, []byte{'\001'})
 	if fieldCount == 0 {
 		return parseError{OrigError: fmt.Sprintf("No Fields detected in %s", string(mp.rawBytes))}
 	}


### PR DESCRIPTION
Not a huge improvement but an improvement nonetheless.

```
goos: darwin
goarch: arm64
pkg: github.com/quickfixgo/quickfix
               │    old3     │                new3                │
               │   sec/op    │   sec/op     vs base               │
ParseMessage-8   680.6n ± 0%   650.0n ± 0%  -4.49% (p=0.000 n=20)
```