### PR TITLE
Only lock fieldmap once during message parsing

### DIFF
--- a/message.go
+++ b/message.go
@@ -181,10 +181,17 @@ func ParseMessageWithDataDictionary(
 
 // doParsing executes the message parsing process.
 func doParsing(mp *msgParser) (err error) {
+	mp.msg.Header.rwLock.Lock()
+	defer mp.msg.Header.rwLock.Unlock()
+	mp.msg.Body.rwLock.Lock()
+	defer mp.msg.Body.rwLock.Unlock()
+	mp.msg.Trailer.rwLock.Lock()
+	defer mp.msg.Trailer.rwLock.Unlock()
+
 	// Initialize for parsing.
-	mp.msg.Header.Clear()
-	mp.msg.Body.Clear()
-	mp.msg.Trailer.Clear()
+	mp.msg.Header.clearNoLock()
+	mp.msg.Body.clearNoLock()
+	mp.msg.Trailer.clearNoLock()
 
 	// Allocate expected message fields in one chunk.
 	fieldCount := 0
@@ -267,7 +274,7 @@ func doParsing(mp *msgParser) (err error) {
 		}
 
 		if mp.parsedFieldBytes.tag == tagXMLDataLen {
-			xmlDataLen, _ = mp.msg.Header.GetInt(tagXMLDataLen)
+			xmlDataLen, _ = mp.msg.Header.getIntNoLock(tagXMLDataLen)
 		}
 		mp.fieldIndex++
 	}
@@ -292,7 +299,7 @@ func doParsing(mp *msgParser) (err error) {
 		}
 	}
 
-	bodyLength, err := mp.msg.Header.GetInt(tagBodyLength)
+	bodyLength, err := mp.msg.Header.getIntNoLock(tagBodyLength)
 	if err != nil {
 		err = parseError{OrigError: err.Error()}
 	} else if length != bodyLength && !xmlDataMsg {
@@ -373,7 +380,7 @@ func parseGroup(mp *msgParser, tags []Tag) {
 // tags slice will contain multiple tags if the tag in question is found while processing a group already.
 func isNumInGroupField(msg *Message, tags []Tag, appDataDictionary *datadictionary.DataDictionary) bool {
 	if appDataDictionary != nil {
-		msgt, err := msg.MsgType()
+		msgt, err := msg.msgTypeNoLock()
 		if err != nil {
 			return false
 		}
@@ -406,7 +413,7 @@ func isNumInGroupField(msg *Message, tags []Tag, appDataDictionary *datadictiona
 // tags slice will contain multiple tags if the tag in question is found while processing a group already.
 func getGroupFields(msg *Message, tags []Tag, appDataDictionary *datadictionary.DataDictionary) (fields []*datadictionary.FieldDef) {
 	if appDataDictionary != nil {
-		msgt, err := msg.MsgType()
+		msgt, err := msg.msgTypeNoLock()
 		if err != nil {
 			return
 		}
@@ -474,6 +481,10 @@ func isTrailerField(tag Tag, dataDict *datadictionary.DataDictionary) bool {
 // MsgType returns MsgType (tag 35) field's value.
 func (m *Message) MsgType() (string, MessageRejectError) {
 	return m.Header.GetString(tagMsgType)
+}
+
+func (m *Message) msgTypeNoLock() (string, MessageRejectError) {
+	return m.Header.getStringNoLock(tagMsgType)
 }
 
 // IsMsgTypeOf returns true if the Header contains MsgType (tag 35) field and its value is the specified one.


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/quickfixgo/quickfix
               │     old     │          new-parse-no-lock          │
               │   sec/op    │   sec/op     vs base                │
ParseMessage-8   695.2n ± 1%   591.0n ± 0%  -14.99% (p=0.000 n=20)
```