### PR TITLE
allow the clients of acceptor to specify their own tls.Config

### DIFF
--- a/accepter_test.go
+++ b/accepter_test.go
@@ -106,7 +106,7 @@ func TestAcceptor_SetTLSConfig(t *testing.T) {
 	// as opposed to the Certificates slice, that is static in nature, and is only populated once and needs application restart to reload the certs.
 	customizedTLSConfig := tls.Config{
 		Certificates: []tls.Certificate{},
-		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 			cert, err := tls.LoadX509KeyPair("_test_data/localhost.crt", "_test_data/localhost.key")
 			if err != nil {
 				return nil, err

--- a/accepter_test.go
+++ b/accepter_test.go
@@ -16,6 +16,7 @@
 package quickfix
 
 import (
+	"crypto/tls"
 	"net"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcceptor_Start(t *testing.T) {
@@ -82,4 +84,45 @@ func TestAcceptor_Start(t *testing.T) {
 			acceptor.Stop()
 		})
 	}
+}
+
+func TestAcceptor_SetTLSConfig(t *testing.T) {
+	sessionSettings := NewSessionSettings()
+	sessionSettings.Set(config.BeginString, BeginStringFIX42)
+	sessionSettings.Set(config.SenderCompID, "sender")
+	sessionSettings.Set(config.TargetCompID, "target")
+
+	genericSettings := NewSettings()
+
+	genericSettings.GlobalSettings().Set("SocketAcceptPort", "5001")
+	_, err := genericSettings.AddSession(sessionSettings)
+	require.NoError(t, err)
+
+	logger, err := NewScreenLogFactory().Create()
+	require.NoError(t, err)
+	acceptor := &Acceptor{settings: genericSettings, globalLog: logger}
+	defer acceptor.Stop()
+	// example of a customized tls.Config that loads the certificates dynamically by the `GetCertificate` function
+	// as opposed to the Certificates slice, that is static in nature, and is only populated once and needs application restart to reload the certs.
+	customizedTLSConfig := tls.Config{
+		Certificates: []tls.Certificate{},
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair("_test_data/localhost.crt", "_test_data/localhost.key")
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		},
+	}
+
+	acceptor.SetTLSConfig(&customizedTLSConfig)
+	assert.NoError(t, acceptor.Start())
+	assert.Len(t, acceptor.listeners, 1)
+
+	conn, err := tls.Dial("tcp", "localhost:5001", &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, conn)
+	defer conn.Close()
 }

--- a/acceptor.go
+++ b/acceptor.go
@@ -426,11 +426,12 @@ func (a *Acceptor) SetConnectionValidator(validator ConnectionValidator) {
 	a.connectionValidator = validator
 }
 
-// SetTLSConfig allows the creator of the Acceptor to specify a fully customizable tls.Config.
-
-// When the caller explicitly provides a tls.Config with this function,
+// SetTLSConfig allows the creator of the Acceptor to specify a fully customizable tls.Config of their choice,
+// which will be used in the Start() method.
+//
+// Note: when the caller explicitly provides a tls.Config with this function,
 // it takes precendent over TLS settings specified in the acceptor's settings.GlobalSettings(),
-// meaning that the setting object is not inspected or used for the creation of the tls.Config.
+// meaning that the `settings.GlobalSettings()` object is not inspected or used for the creation of the tls.Config.
 func (a *Acceptor) SetTLSConfig(tlsConfig *tls.Config) {
 	a.tlsConfig = tlsConfig
 }

--- a/acceptor.go
+++ b/acceptor.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"runtime/debug"
@@ -48,6 +49,7 @@ type Acceptor struct {
 	sessionHostPort       map[SessionID]int
 	listeners             map[string]net.Listener
 	connectionValidator   ConnectionValidator
+	tlsConfig             *tls.Config
 	sessionFactory
 }
 
@@ -81,9 +83,12 @@ func (a *Acceptor) Start() (err error) {
 		a.listeners[address] = nil
 	}
 
-	var tlsConfig *tls.Config
-	if tlsConfig, err = loadTLSConfig(a.settings.GlobalSettings()); err != nil {
-		return
+	if a.tlsConfig == nil {
+		var tlsConfig *tls.Config
+		if tlsConfig, err = loadTLSConfig(a.settings.GlobalSettings()); err != nil {
+			return
+		}
+		a.tlsConfig = tlsConfig
 	}
 
 	var useTCPProxy bool
@@ -94,8 +99,8 @@ func (a *Acceptor) Start() (err error) {
 	}
 
 	for address := range a.listeners {
-		if tlsConfig != nil {
-			if a.listeners[address], err = tls.Listen("tcp", address, tlsConfig); err != nil {
+		if a.tlsConfig != nil {
+			if a.listeners[address], err = tls.Listen("tcp", address, a.tlsConfig); err != nil {
 				return
 			}
 		} else if a.listeners[address], err = net.Listen("tcp", address); err != nil {
@@ -228,6 +233,7 @@ func (a *Acceptor) invalidMessage(msg *bytes.Buffer, err error) {
 func (a *Acceptor) handleConnection(netConn net.Conn) {
 	defer func() {
 		if err := recover(); err != nil {
+			fmt.Println("asdqwe", a.globalLog)
 			a.globalLog.OnEventf("Connection Terminated with Panic: %s", debug.Stack())
 		}
 
@@ -420,4 +426,13 @@ LOOP:
 //	a.SetConnectionValidator(nil)
 func (a *Acceptor) SetConnectionValidator(validator ConnectionValidator) {
 	a.connectionValidator = validator
+}
+
+// SetTLSConfig allows the creator of the Acceptor to specify a fully customizable tls.Config.
+
+// When the caller explicitly provides a tls.Config with this function,
+// it takes precendent over TLS settings specified in the acceptor's settings.GlobalSettings(),
+// meaning that the setting object is not inspected or used for the creation of the tls.Config.
+func (a *Acceptor) SetTLSConfig(tlsConfig *tls.Config) {
+	a.tlsConfig = tlsConfig
 }

--- a/acceptor.go
+++ b/acceptor.go
@@ -19,7 +19,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net"
 	"runtime/debug"
@@ -233,7 +232,6 @@ func (a *Acceptor) invalidMessage(msg *bytes.Buffer, err error) {
 func (a *Acceptor) handleConnection(netConn net.Conn) {
 	defer func() {
 		if err := recover(); err != nil {
-			fmt.Println("asdqwe", a.globalLog)
 			a.globalLog.OnEventf("Connection Terminated with Panic: %s", debug.Stack())
 		}
 


### PR DESCRIPTION
TLS certs go stale / expire overtime.

When they do, they need to be renewed.

Originally, when a server (acceptor) starts up, it configures its tls.Config to use for tls connections. 
When this tls.Config uses / is set up with `Certificates []Certificate`, then the cert will be stored / remain in memory, and will be static in nature. Any renewal on the disk would not affect that Certificates slice. The only way to effectuate the new certs is to reboot the server.

This reboot may be undesirable / unnecessary, if the server would be able to load the server cert on demand.

Golang solves this issue, by allowing the tls.Config to load the server cert by a user specified function (`GetCertificate`).

This PR would allow the developer to specify a tls.Config of their choice, and in turn would allow them to be fully in control of the tls.Config of the acceptor (including the specification of such `GetCertificate` function to avoid downtime in case of cert renewal) 