### PR TITLE
Avoid unkeyed fields usage for exported struct in generated code

### DIFF
--- a/cmd/generate-fix/internal/templates.go
+++ b/cmd/generate-fix/internal/templates.go
@@ -282,9 +282,9 @@ type {{ .Name }} struct {
 // FromMessage creates a {{ .Name }} from a quickfix.Message instance.
 func FromMessage(m *quickfix.Message) {{ .Name }} {
 	return {{ .Name }}{
-		Header: {{ .TransportPackage}}.Header{&m.Header},
+		Header: {{ .TransportPackage}}.Header{Header: &m.Header},
 		Body: &m.Body,
-		Trailer: {{ .TransportPackage}}.Trailer{&m.Trailer},
+		Trailer: {{ .TransportPackage}}.Trailer{Trailer: &m.Trailer},
 		Message: m,
 	}
 }


### PR DESCRIPTION
This updates Go code template to avoid unkeyed fields usage for exported struct.

I'm using `generate-fix` command to generate my own custom FIX application. 
However, Go standard linter, `go vet`, raises an alert because the generated Header/Trailer struct literal uses unkeyed fields.
https://github.com/golang/tools/blob/master/go/analysis/passes/composite/composite.go

While I understand the unkeyed field usage is valid for generated code, it can be somewhat inconvenient to exclude generated code from vet target or disable composite analysis entirely by `go vet -composites=false ./...`.
It would be preferable if the generated code adhered to the recommended style to avoid such issues.