### PR TITLE
[YO-1111] Allow OrigTimestamp field to be ignored

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -1126,4 +1126,17 @@ const (
 	//  - Y
 	//  - N
 	EnableNextExpectedMsgSeqNum string = "EnableNextExpectedMsgSeqNum"
+
+	// CheckOriginalTimestamp if set to Y, the FIX engine will check the OrigSendingTime (tag 122) in the header of incoming messages.
+	// When enabled, if the OrigSendingTime is not present or the original sending time is later than the SendingTime (tag 52),
+	// the message will be rejected.
+	//
+	// Required: No
+	//
+	// Default: Y
+	//
+	// Valid Values:
+	//  - Y
+	//  - N
+	CheckOriginalTimestamp string = "CheckOriginalTimestamp"
 )

--- a/in_session.go
+++ b/in_session.go
@@ -353,6 +353,10 @@ func (state inSession) doTargetTooLow(session *session, msg *Message, rej target
 		return logoutState{}
 	}
 
+	if session.SessionSettings.DisableCheckOriginalTimestamp {
+		return state
+	}
+
 	if !msg.Header.Has(tagOrigSendingTime) {
 		if err := session.doReject(msg, RequiredTagMissing(tagOrigSendingTime)); err != nil {
 			return handleStateError(session, err)

--- a/internal/session_settings.go
+++ b/internal/session_settings.go
@@ -19,6 +19,8 @@ type SessionSettings struct {
 	MaxLatency                   time.Duration
 	DisableMessagePersist        bool
 
+	DisableCheckOriginalTimestamp bool
+
 	// Required on logon for FIX.T.1 messages.
 	DefaultApplVerID string
 

--- a/session_factory.go
+++ b/session_factory.go
@@ -202,6 +202,15 @@ func (f sessionFactory) newSession(
 		}
 	}
 
+	if settings.HasSetting(config.CheckOriginalTimestamp) {
+		var checkTimestamp bool
+		if checkTimestamp, err = settings.BoolSetting(config.CheckOriginalTimestamp); err != nil {
+			return
+		}
+
+		s.DisableCheckOriginalTimestamp = !checkTimestamp
+	}
+
 	if settings.HasSetting(config.CheckLatency) {
 		var doCheckLatency bool
 		if doCheckLatency, err = settings.BoolSetting(config.CheckLatency); err != nil {


### PR DESCRIPTION
Coinbase doesn't send this field, so add an option not to check it when getting messages that are potentially out of order.