### PR TITLE
Fix int overflow in parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -132,7 +132,10 @@ func (p *parser) jumpLength() (int, error) {
 		return length, err
 	}
 
-	if length <= 0 {
+	// Issue 678: if length approaches the int limit, it might overflow when
+	// adding offset and make it negative so we also need to check that
+	// offset+length is not negative.
+	if length <= 0 || offset+length <= 0 {
 		return length, errors.New("Invalid length")
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -186,3 +186,14 @@ func (s *ParserSuite) TestReadMessageGrowBuffer() {
 		s.Equal(tc.expectedBufferLen, len(s.parser.buffer))
 	}
 }
+
+// https://github.com/quickfixgo/quickfix/issues/678
+func TestIssue678(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+	parser := newParser(strings.NewReader(string("8=\x019=119999999999999999999999999999999999999999999999999999999999970\x01")))
+	_, _ = parser.ReadMessage()
+}


### PR DESCRIPTION
A maliciously crafted message with a bogus body length could make the parser panic if the body length is close to the int limit.

Fixes https://github.com/quickfixgo/quickfix/issues/678