### PR TITLE
implement stringer interface for enums

### DIFF
--- a/cmd/generate-fix/internal/templates.go
+++ b/cmd/generate-fix/internal/templates.go
@@ -450,6 +450,15 @@ const(
 {{ $ft.Name }}_{{ .Description }} {{ $ft.Name }} = "{{ .Value }}"
 {{- end }}
 )
+func ({{ $ft.Name }} {{ $ft.Name }}) String() string {
+ switch {{ $ft.Name }} {
+ {{- range $ft.Enums }}
+ case {{ $ft.Name }}_{{ .Description }}:
+	return "{{ .Description }}"
+ {{- end }}
+ }
+ return "Unknown_{{ $ft.Name }}"
+}
 {{ end }}{{ end }}
 	`))
 }


### PR DESCRIPTION
Adds the `String()` function to enums, satisfying the `fmt.Stringer` interface. Returns the enum description and falls back to "Unknown_{EnumNameHere}" if for some reason a case hasn't been accounted for automatically.