### PR TITLE
Fix: Incorrect message body length when resending messages

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -259,7 +259,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 		}
 
 		session.log.OnEventf("Resending Message: %v", sentMessageSeqNum)
-		msgBytes = msg.buildWithBodyBytes(msg.bodyBytes) // workaround for maintaining repeating group field order
+		msgBytes = msg.build()
 		session.EnqueueBytesAndSend(msgBytes)
 
 		seqNum = sentMessageSeqNum + 1

--- a/message.go
+++ b/message.go
@@ -597,21 +597,6 @@ func (m *Message) build() []byte {
 	return b.Bytes()
 }
 
-// Constructs a []byte from a Message instance, using the given bodyBytes.
-// This is a workaround for the fact that we currently rely on the generated Message types to properly serialize/deserialize RepeatingGroups.
-// In other words, we cannot go from bytes to a Message then back to bytes, which is exactly what we need to do in the case of a Resend.
-// This func lets us pull the Message from the Store, parse it, update the Header, and then build it back into bytes using the original Body.
-// Note: The only standard non-Body group is NoHops.  If that is used in the Header, this workaround may fail.
-func (m *Message) buildWithBodyBytes(bodyBytes []byte) []byte {
-	m.cook()
-
-	var b bytes.Buffer
-	m.Header.write(&b)
-	b.Write(bodyBytes)
-	m.Trailer.write(&b)
-	return b.Bytes()
-}
-
 func (m *Message) cook() {
 	bodyLength := m.Header.length() + m.Body.length() + m.Trailer.length()
 	m.Header.SetInt(tagBodyLength, bodyLength)

--- a/message_test.go
+++ b/message_test.go
@@ -383,41 +383,6 @@ func (s *MessageSuite) TestRebuildDoubleNestedWithTwoMembersRepeatingGroupWithDi
 	s.True(bytes.Equal(expectedBytes, rebuildBytes), "Unexpected bytes,\n expected: %s\n but got: %s", expectedBytes, rebuildBytes)
 }
 
-func (s *MessageSuite) TestReBuildWithRepeatingGroupForResend() {
-	// Given the following message with a repeating group
-	origHeader := "8=FIXT.1.19=16135=834=349=ISLD52=20240415-03:43:17.92356=TW"
-	origBody := "6=1.0011=114=1.0017=131=1.0032=1.0037=138=1.0039=254=155=1150=2151=0.00453=1448=xyzzy447=D452=1"
-	origTrailer := "10=014"
-	rawMsg := bytes.NewBufferString(origHeader + origBody + origTrailer)
-
-	// When I reparse the message from the store during a resend request
-	s.Nil(ParseMessage(s.msg, rawMsg))
-
-	// And I update the headers for resend
-	s.msg.Header.SetField(tagOrigSendingTime, FIXString("20240415-03:43:17.923"))
-	s.msg.Header.SetField(tagSendingTime, FIXString("20240415-14:41:23.456"))
-	s.msg.Header.SetField(tagPossDupFlag, FIXBoolean(true))
-
-	// When I rebuild the message
-	rebuildBytes := s.msg.build()
-
-	// Then the repeating groups will not be in the correct order in the rebuilt message (note tags 447, 448, 452, 453)
-	expectedBytes := []byte("8=FIXT.1.19=19235=834=343=Y49=ISLD52=20240415-14:41:23.45656=TW122=20240415-03:43:17.9236=1.0011=114=1.0017=131=1.0032=1.0037=138=1.0039=254=155=1150=2151=0.00453=1448=xyzzy447=D452=110=018")
-	s.False(bytes.Equal(expectedBytes, rebuildBytes), "Unexpected bytes,\n expected: %s\n  but was: %s", expectedBytes, rebuildBytes)
-	expectedOutOfOrderBytes := []byte("8=FIXT.1.19=19235=834=343=Y49=ISLD52=20240415-14:41:23.45656=TW122=20240415-03:43:17.9236=1.0011=114=1.0017=131=1.0032=1.0037=138=1.0039=254=155=1150=2151=0.00447=D448=xyzzy452=1453=110=018")
-	s.True(bytes.Equal(expectedOutOfOrderBytes, rebuildBytes), "Unexpected bytes,\n expected: %s\n  but was: %s", expectedOutOfOrderBytes, rebuildBytes)
-
-	// But the bodyBytes will still be correct
-	origBodyBytes := []byte(origBody)
-	s.True(bytes.Equal(origBodyBytes, s.msg.bodyBytes), "Incorrect body bytes, \n expected: %s\n  but was: %s", origBodyBytes, s.msg.bodyBytes)
-
-	// So when I combine the updated header + the original bodyBytes + the as-is trailer
-	resendBytes := s.msg.buildWithBodyBytes(s.msg.bodyBytes)
-
-	// Then the reparsed, rebuilt message will retain the correct ordering of repeating group tags during resend
-	s.True(bytes.Equal(expectedBytes, resendBytes), "Unexpected bytes,\n expected: %s\n  but was: %s", expectedBytes, resendBytes)
-}
-
 func (s *MessageSuite) TestReverseRoute() {
 	s.Nil(ParseMessage(s.msg, bytes.NewBufferString("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
 


### PR DESCRIPTION
Currently, support has been established for processing repeating groups through the data dictionary. Theoretically, there should no longer be a need to utilize such workaround methods for message resending. Moreover, the `buildWithBodyBytes` method could also introduce errors related to the message body length.