### PR TITLE
update go api documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go get -u github.com/quickfixgo/quickfix
 
 ## Getting Started
 
-* [QuickFIX User Manual](http://quickfixgo.org/docs)
+* [QuickFIX User Manual](https://quickfixengine.org/go/documentation/)
 * [Go API Documentation](https://godoc.org/github.com/quickfixgo/quickfix)
 * See [examples](https://github.com/quickfixgo/examples) for some simple examples of using QuickFIX/Go.
 


### PR DESCRIPTION
Actual link (404): http://quickfixgo.org/docs 
<img width="1212" height="827" alt="Screenshot 2025-08-07 at 12 26 48 PM" src="https://github.com/user-attachments/assets/fdd931b2-af25-4bbc-a595-c1739ffad3d1" />


New link: https://quickfixengine.org/go/documentation/
<img width="1212" height="827" alt="Screenshot 2025-08-07 at 12 26 48 PM" src="https://github.com/user-attachments/assets/6d54ea4e-38c1-4853-a5a5-8feabd4dffc4" />
