### PR TITLE
Handle logon error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -15,10 +15,19 @@
 
 package quickfix
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
-func writeLoop(connection io.Writer, messageOut chan []byte, log Log) {
+func writeLoop(ctx context.Context, connection io.Writer, messageOut chan []byte, log Log) {
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		msg, ok := <-messageOut
 		if !ok {
 			return
@@ -30,10 +39,16 @@ func writeLoop(connection io.Writer, messageOut chan []byte, log Log) {
 	}
 }
 
-func readLoop(parser *parser, msgIn chan fixIn, log Log) {
+func readLoop(ctx context.Context, parser *parser, msgIn chan fixIn, log Log) {
 	defer close(msgIn)
 
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		msg, err := parser.ReadMessage()
 		if err != nil {
 			log.OnEvent(err.Error())

--- a/connection_internal_test.go
+++ b/connection_internal_test.go
@@ -17,11 +17,13 @@ package quickfix
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 )
 
 func TestWriteLoop(t *testing.T) {
+	ctx := context.Background()
 	writer := bytes.NewBufferString("")
 	msgOut := make(chan []byte)
 
@@ -31,7 +33,7 @@ func TestWriteLoop(t *testing.T) {
 		msgOut <- []byte("test msg 3")
 		close(msgOut)
 	}()
-	writeLoop(writer, msgOut, nullLog{})
+	writeLoop(ctx, writer, msgOut, nullLog{})
 
 	expected := "test msg 1 test msg 2 test msg 3"
 
@@ -41,11 +43,12 @@ func TestWriteLoop(t *testing.T) {
 }
 
 func TestReadLoop(t *testing.T) {
+	ctx := context.Background()
 	msgIn := make(chan fixIn)
 	stream := "hello8=FIX.4.09=5blah10=103garbage8=FIX.4.09=4foo10=103"
 
 	parser := newParser(strings.NewReader(stream))
-	go readLoop(parser, msgIn, nullLog{})
+	go readLoop(ctx, parser, msgIn, nullLog{})
 
 	var tests = []struct {
 		expectedMsg   string

--- a/initiator.go
+++ b/initiator.go
@@ -210,12 +210,11 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 
 		msgIn = make(chan fixIn)
 		msgOut = make(chan []byte)
-	
 
-		go readLoop(readWriteCtx,newParser(bufio.NewReader(netConn)), msgIn, session.log)
+		go readLoop(readWriteCtx, newParser(bufio.NewReader(netConn)), msgIn, session.log)
 		disconnected = make(chan interface{})
 		go func() {
-			writeLoop(readWriteCtx,netConn, msgOut, session.log)
+			writeLoop(readWriteCtx, netConn, msgOut, session.log)
 			if err := netConn.Close(); err != nil {
 				session.log.OnEvent(err.Error())
 			}

--- a/initiator.go
+++ b/initiator.go
@@ -163,14 +163,17 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 			return
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx := context.Background()
+		dialCtx, dialCancel := context.WithCancel(ctx)
+		readWriteCtx, readWriteCancel := context.WithCancel(ctx)
 
 		// We start a goroutine in order to be able to cancel the dialer mid-connection
 		// on receiving a stop signal to stop the initiator.
 		go func() {
 			select {
 			case <-i.stopChan:
-				cancel()
+				dialCancel()
+				readWriteCancel()
 			case <-ctx.Done():
 				return
 			}
@@ -183,7 +186,7 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 		address := session.SocketConnectAddress[connectionAttempt%len(session.SocketConnectAddress)]
 		session.log.OnEventf("Connecting to: %v", address)
 
-		netConn, err := dialer.DialContext(ctx, "tcp", address)
+		netConn, err := dialer.DialContext(dialCtx, "tcp", address)
 		if err != nil {
 			session.log.OnEventf("Failed to connect: %v", err)
 			goto reconnect
@@ -207,24 +210,26 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 
 		msgIn = make(chan fixIn)
 		msgOut = make(chan []byte)
-		if err := session.connect(msgIn, msgOut); err != nil {
-			session.log.OnEventf("Failed to initiate: %v", err)
-			goto reconnect
-		}
+	
 
-		go readLoop(newParser(bufio.NewReader(netConn)), msgIn, session.log)
+		go readLoop(readWriteCtx,newParser(bufio.NewReader(netConn)), msgIn, session.log)
 		disconnected = make(chan interface{})
 		go func() {
-			writeLoop(netConn, msgOut, session.log)
+			writeLoop(readWriteCtx,netConn, msgOut, session.log)
 			if err := netConn.Close(); err != nil {
 				session.log.OnEvent(err.Error())
 			}
 			close(disconnected)
 		}()
 
+		if err := session.connect(msgIn, msgOut); err != nil {
+			session.log.OnEventf("Failed to initiate: %v", err)
+			goto reconnect
+		}
+
 		// This ensures we properly cleanup the goroutine and context used for
 		// dial cancelation after successful connection.
-		cancel()
+		dialCancel()
 
 		select {
 		case <-disconnected:
@@ -233,7 +238,7 @@ func (i *Initiator) handleConnection(session *session, tlsConfig *tls.Config, di
 		}
 
 	reconnect:
-		cancel()
+		dialCancel()
 
 		connectionAttempt++
 		session.log.OnEventf("Reconnecting in %v", session.ReconnectInterval)

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -1,0 +1,172 @@
+package quickfix
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quickfixgo/quickfix/config"
+)
+
+func TestNewInitiatorKeepReconnectingAfterLogonError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logonCount := 0
+	app := &mockApplication{}
+	storeFactory := &mockMessageStoreFactory{saveMessageAndIncrError: errDBError}
+	logFactory := &mockLogFactory{
+		onEvent: func(s string) {
+			if s == "Sending logon request" {
+				logonCount++
+				if logonCount >= 5 {
+					cancel()
+				}
+			}
+		},
+	}
+	
+	settings := NewSettings()
+	sessionSettings := newSession()
+	sessionID,err :=settings.AddSession(sessionSettings)
+	if err != nil {
+		t.Fatalf("Expected no error adding session, got %v", err)
+	}
+
+	initiator, err := NewInitiator(app, storeFactory, settings, logFactory)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	s, ok := initiator.sessions[sessionID]
+	if !ok {
+		t.Fatal("Expected session to be created")
+	}
+
+	initiator.stopChan = make(chan interface{})
+	go initiator.handleConnection(s,nil,&mockDialer{})
+	
+
+	select {
+		case <-ctx.Done():
+			initiator.Stop()
+			return
+		case <-time.After(10 * time.Second):
+			t.Error("retry stopped after logon error")
+			return
+	}
+}
+
+func newSession() *SessionSettings {
+	sessionSettings := NewSessionSettings()
+	sessionSettings.Set(config.BeginString, "FIX.4.4")
+	sessionSettings.Set(config.SenderCompID, "X")
+	sessionSettings.Set(config.TargetCompID, "X")
+	sessionSettings.Set(config.HeartBtInt, "30")
+	sessionSettings.Set(config.SocketConnectHost, "localhost")
+	sessionSettings.Set(config.SocketConnectPort, "9878")
+	sessionSettings.Set(config.ReconnectInterval, "1")
+	return sessionSettings
+}
+
+type mockApplication struct{}
+
+func (m *mockApplication) OnCreate(sessionID SessionID)                           {}
+func (m *mockApplication) OnLogon(sessionID SessionID)                            {}
+func (m *mockApplication) OnLogout(sessionID SessionID)                           {}
+func (m *mockApplication) ToAdmin(message *Message, sessionID SessionID)          {}
+func (m *mockApplication) ToApp(message *Message, sessionID SessionID) error      { return nil }
+func (m *mockApplication) FromAdmin(message *Message, sessionID SessionID) MessageRejectError { return nil }
+func (m *mockApplication) FromApp(message *Message, sessionID SessionID) MessageRejectError { return nil }
+
+type mockMessageStoreFactory struct{
+	saveMessageAndIncrError error
+}
+
+func (m *mockMessageStoreFactory) Create(sessionID SessionID) (MessageStore, error) {
+	return &mockMessageStore{saveMessageAndIncrError: m.saveMessageAndIncrError}, nil
+}
+
+var errDBError = errors.New("db error")
+
+type mockMessageStore struct{
+	saveMessageAndIncrError error
+}
+
+func (m *mockMessageStore) NextSenderMsgSeqNum() int                    { return 1 }
+func (m *mockMessageStore) NextTargetMsgSeqNum() int                    { return 1 }
+func (m *mockMessageStore) IncrSenderMsgSeqNum() error                  { return nil }
+func (m *mockMessageStore) IncrTargetMsgSeqNum() error                  { return nil }
+func (m *mockMessageStore) SetNextSenderMsgSeqNum(next int) error       { return nil }
+func (m *mockMessageStore) SetNextTargetMsgSeqNum(next int) error       { return nil }
+func (m *mockMessageStore) CreationTime() time.Time                     { return time.Now() }
+func (m *mockMessageStore) SaveMessage(seqNum int, msg []byte) error    { return nil }
+func (m *mockMessageStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) { return nil, nil }
+func (m *mockMessageStore) Refresh() error                              { return nil }
+func (m *mockMessageStore) Reset() error                                { return nil }
+func (m *mockMessageStore) Close() error                                { return nil }
+func (m *mockMessageStore) IncrNextSenderMsgSeqNum() error {return nil}
+func (m *mockMessageStore) IncrNextTargetMsgSeqNum() error {return nil}
+func (m *mockMessageStore) IterateMessages(int, int, func([]byte) error)  error {return nil}
+func (m *mockMessageStore) SaveMessageAndIncrNextSenderMsgSeqNum(seqNum int, msg []byte) error { return m.saveMessageAndIncrError }
+func (m *mockMessageStore) SetCreationTime(time.Time) {}
+
+type mockLogFactory struct {
+	shouldFail bool
+	onEvent	func(string)
+}
+
+func (m *mockLogFactory) Create() (Log, error) {
+	if m.shouldFail {
+		return nil, errors.New("log factory error")
+	}
+	return &mockLog{
+		onEvent: m.onEvent,
+	}, nil
+}
+
+func (m *mockLogFactory) CreateSessionLog(sessionID SessionID) (Log, error) {
+	return &mockLog{
+		onEvent: m.onEvent,
+	}, nil
+}
+
+type mockDialer struct{}
+
+type mockAddr struct {
+	network string
+	address string
+}
+
+func (m *mockAddr) Network() string { return m.network }
+func (m *mockAddr) String() string  { return m.address }
+
+type mockConn struct {}
+
+func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (m *mockConn) Write(b []byte) (n int, err error)  { return len(b), nil }
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr               { return &mockAddr{network: "tcp", address: "127.0.0.1:8080"} }
+func (m *mockConn) RemoteAddr() net.Addr              { return &mockAddr{network: "tcp", address: "127.0.0.1:9090"} }
+func (m *mockConn) SetDeadline(t time.Time) error     { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (m *mockDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error){
+	return &mockConn{}, nil
+}
+
+type mockLog struct{
+	onEvent func(string)
+}
+
+func (m *mockLog) OnIncoming(s []byte)      {}
+func (m *mockLog) OnOutgoing(s []byte)      {}
+func (m *mockLog) OnEvent(s string)         {
+	if m.onEvent != nil {
+		m.onEvent(s)
+	}
+}
+func (m *mockLog) OnEventf(format string, a ...interface{}) {}

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -72,15 +72,15 @@ func newSession() *SessionSettings {
 
 type mockApplication struct{}
 
-func (m *mockApplication) OnCreate(sessionID SessionID)                      {}
-func (m *mockApplication) OnLogon(sessionID SessionID)                       {}
-func (m *mockApplication) OnLogout(sessionID SessionID)                      {}
-func (m *mockApplication) ToAdmin(message *Message, sessionID SessionID)     {}
-func (m *mockApplication) ToApp(message *Message, sessionID SessionID) error { return nil }
-func (m *mockApplication) FromAdmin(message *Message, sessionID SessionID) MessageRejectError {
+func (m *mockApplication) OnCreate(_ SessionID)                {}
+func (m *mockApplication) OnLogon(_ SessionID)                 {}
+func (m *mockApplication) OnLogout(_ SessionID)                {}
+func (m *mockApplication) ToAdmin(_ *Message, _ SessionID)     {}
+func (m *mockApplication) ToApp(_ *Message, _ SessionID) error { return nil }
+func (m *mockApplication) FromAdmin(_ *Message, _ SessionID) MessageRejectError {
 	return nil
 }
-func (m *mockApplication) FromApp(message *Message, sessionID SessionID) MessageRejectError {
+func (m *mockApplication) FromApp(_ *Message, _ SessionID) MessageRejectError {
 	return nil
 }
 
@@ -88,7 +88,7 @@ type mockMessageStoreFactory struct {
 	saveMessageAndIncrError error
 }
 
-func (m *mockMessageStoreFactory) Create(sessionID SessionID) (MessageStore, error) {
+func (m *mockMessageStoreFactory) Create(_ SessionID) (MessageStore, error) {
 	return &mockMessageStore{saveMessageAndIncrError: m.saveMessageAndIncrError}, nil
 }
 
@@ -98,22 +98,22 @@ type mockMessageStore struct {
 	saveMessageAndIncrError error
 }
 
-func (m *mockMessageStore) NextSenderMsgSeqNum() int                                 { return 1 }
-func (m *mockMessageStore) NextTargetMsgSeqNum() int                                 { return 1 }
-func (m *mockMessageStore) IncrSenderMsgSeqNum() error                               { return nil }
-func (m *mockMessageStore) IncrTargetMsgSeqNum() error                               { return nil }
-func (m *mockMessageStore) SetNextSenderMsgSeqNum(next int) error                    { return nil }
-func (m *mockMessageStore) SetNextTargetMsgSeqNum(next int) error                    { return nil }
-func (m *mockMessageStore) CreationTime() time.Time                                  { return time.Now() }
-func (m *mockMessageStore) SaveMessage(seqNum int, msg []byte) error                 { return nil }
-func (m *mockMessageStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) { return nil, nil }
-func (m *mockMessageStore) Refresh() error                                           { return nil }
-func (m *mockMessageStore) Reset() error                                             { return nil }
-func (m *mockMessageStore) Close() error                                             { return nil }
-func (m *mockMessageStore) IncrNextSenderMsgSeqNum() error                           { return nil }
-func (m *mockMessageStore) IncrNextTargetMsgSeqNum() error                           { return nil }
-func (m *mockMessageStore) IterateMessages(int, int, func([]byte) error) error       { return nil }
-func (m *mockMessageStore) SaveMessageAndIncrNextSenderMsgSeqNum(seqNum int, msg []byte) error {
+func (m *mockMessageStore) NextSenderMsgSeqNum() int                           { return 1 }
+func (m *mockMessageStore) NextTargetMsgSeqNum() int                           { return 1 }
+func (m *mockMessageStore) IncrSenderMsgSeqNum() error                         { return nil }
+func (m *mockMessageStore) IncrTargetMsgSeqNum() error                         { return nil }
+func (m *mockMessageStore) SetNextSenderMsgSeqNum(_ int) error                 { return nil }
+func (m *mockMessageStore) SetNextTargetMsgSeqNum(_ int) error                 { return nil }
+func (m *mockMessageStore) CreationTime() time.Time                            { return time.Now() }
+func (m *mockMessageStore) SaveMessage(_ int, _ []byte) error                  { return nil }
+func (m *mockMessageStore) GetMessages(_, _ int) ([][]byte, error)             { return nil, nil }
+func (m *mockMessageStore) Refresh() error                                     { return nil }
+func (m *mockMessageStore) Reset() error                                       { return nil }
+func (m *mockMessageStore) Close() error                                       { return nil }
+func (m *mockMessageStore) IncrNextSenderMsgSeqNum() error                     { return nil }
+func (m *mockMessageStore) IncrNextTargetMsgSeqNum() error                     { return nil }
+func (m *mockMessageStore) IterateMessages(int, int, func([]byte) error) error { return nil }
+func (m *mockMessageStore) SaveMessageAndIncrNextSenderMsgSeqNum(_ int, _ []byte) error {
 	return m.saveMessageAndIncrError
 }
 func (m *mockMessageStore) SetCreationTime(time.Time) {}
@@ -132,7 +132,7 @@ func (m *mockLogFactory) Create() (Log, error) {
 	}, nil
 }
 
-func (m *mockLogFactory) CreateSessionLog(sessionID SessionID) (Log, error) {
+func (m *mockLogFactory) CreateSessionLog(_ SessionID) (Log, error) {
 	return &mockLog{
 		onEvent: m.onEvent,
 	}, nil
@@ -150,16 +150,16 @@ func (m *mockAddr) String() string  { return m.address }
 
 type mockConn struct{}
 
-func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
-func (m *mockConn) Write(b []byte) (n int, err error)  { return len(b), nil }
+func (m *mockConn) Read(_ []byte) (n int, err error)   { return 0, nil }
+func (m *mockConn) Write(_ []byte) (n int, err error)  { return 0, nil }
 func (m *mockConn) Close() error                       { return nil }
 func (m *mockConn) LocalAddr() net.Addr                { return &mockAddr{network: "tcp", address: "127.0.0.1:8080"} }
 func (m *mockConn) RemoteAddr() net.Addr               { return &mockAddr{network: "tcp", address: "127.0.0.1:9090"} }
-func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
-func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
-func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+func (m *mockConn) SetDeadline(_ time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(_ time.Time) error { return nil }
 
-func (m *mockDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (m *mockDialer) DialContext(_ context.Context, _, _ string) (net.Conn, error) {
 	return &mockConn{}, nil
 }
 
@@ -167,11 +167,11 @@ type mockLog struct {
 	onEvent func(string)
 }
 
-func (m *mockLog) OnIncoming(s []byte) {}
-func (m *mockLog) OnOutgoing(s []byte) {}
+func (m *mockLog) OnIncoming(_ []byte) {}
+func (m *mockLog) OnOutgoing(_ []byte) {}
 func (m *mockLog) OnEvent(s string) {
 	if m.onEvent != nil {
 		m.onEvent(s)
 	}
 }
-func (m *mockLog) OnEventf(format string, a ...interface{}) {}
+func (m *mockLog) OnEventf(_ string, _ ...interface{}) {}

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -27,10 +27,10 @@ func TestNewInitiatorKeepReconnectingAfterLogonError(t *testing.T) {
 			}
 		},
 	}
-	
+
 	settings := NewSettings()
 	sessionSettings := newSession()
-	sessionID,err :=settings.AddSession(sessionSettings)
+	sessionID, err := settings.AddSession(sessionSettings)
 	if err != nil {
 		t.Fatalf("Expected no error adding session, got %v", err)
 	}
@@ -46,16 +46,15 @@ func TestNewInitiatorKeepReconnectingAfterLogonError(t *testing.T) {
 	}
 
 	initiator.stopChan = make(chan interface{})
-	go initiator.handleConnection(s,nil,&mockDialer{})
-	
+	go initiator.handleConnection(s, nil, &mockDialer{})
 
 	select {
-		case <-ctx.Done():
-			initiator.Stop()
-			return
-		case <-time.After(10 * time.Second):
-			t.Error("retry stopped after logon error")
-			return
+	case <-ctx.Done():
+		initiator.Stop()
+		return
+	case <-time.After(10 * time.Second):
+		t.Error("retry stopped after logon error")
+		return
 	}
 }
 
@@ -73,15 +72,19 @@ func newSession() *SessionSettings {
 
 type mockApplication struct{}
 
-func (m *mockApplication) OnCreate(sessionID SessionID)                           {}
-func (m *mockApplication) OnLogon(sessionID SessionID)                            {}
-func (m *mockApplication) OnLogout(sessionID SessionID)                           {}
-func (m *mockApplication) ToAdmin(message *Message, sessionID SessionID)          {}
-func (m *mockApplication) ToApp(message *Message, sessionID SessionID) error      { return nil }
-func (m *mockApplication) FromAdmin(message *Message, sessionID SessionID) MessageRejectError { return nil }
-func (m *mockApplication) FromApp(message *Message, sessionID SessionID) MessageRejectError { return nil }
+func (m *mockApplication) OnCreate(sessionID SessionID)                      {}
+func (m *mockApplication) OnLogon(sessionID SessionID)                       {}
+func (m *mockApplication) OnLogout(sessionID SessionID)                      {}
+func (m *mockApplication) ToAdmin(message *Message, sessionID SessionID)     {}
+func (m *mockApplication) ToApp(message *Message, sessionID SessionID) error { return nil }
+func (m *mockApplication) FromAdmin(message *Message, sessionID SessionID) MessageRejectError {
+	return nil
+}
+func (m *mockApplication) FromApp(message *Message, sessionID SessionID) MessageRejectError {
+	return nil
+}
 
-type mockMessageStoreFactory struct{
+type mockMessageStoreFactory struct {
 	saveMessageAndIncrError error
 }
 
@@ -91,31 +94,33 @@ func (m *mockMessageStoreFactory) Create(sessionID SessionID) (MessageStore, err
 
 var errDBError = errors.New("db error")
 
-type mockMessageStore struct{
+type mockMessageStore struct {
 	saveMessageAndIncrError error
 }
 
-func (m *mockMessageStore) NextSenderMsgSeqNum() int                    { return 1 }
-func (m *mockMessageStore) NextTargetMsgSeqNum() int                    { return 1 }
-func (m *mockMessageStore) IncrSenderMsgSeqNum() error                  { return nil }
-func (m *mockMessageStore) IncrTargetMsgSeqNum() error                  { return nil }
-func (m *mockMessageStore) SetNextSenderMsgSeqNum(next int) error       { return nil }
-func (m *mockMessageStore) SetNextTargetMsgSeqNum(next int) error       { return nil }
-func (m *mockMessageStore) CreationTime() time.Time                     { return time.Now() }
-func (m *mockMessageStore) SaveMessage(seqNum int, msg []byte) error    { return nil }
+func (m *mockMessageStore) NextSenderMsgSeqNum() int                                 { return 1 }
+func (m *mockMessageStore) NextTargetMsgSeqNum() int                                 { return 1 }
+func (m *mockMessageStore) IncrSenderMsgSeqNum() error                               { return nil }
+func (m *mockMessageStore) IncrTargetMsgSeqNum() error                               { return nil }
+func (m *mockMessageStore) SetNextSenderMsgSeqNum(next int) error                    { return nil }
+func (m *mockMessageStore) SetNextTargetMsgSeqNum(next int) error                    { return nil }
+func (m *mockMessageStore) CreationTime() time.Time                                  { return time.Now() }
+func (m *mockMessageStore) SaveMessage(seqNum int, msg []byte) error                 { return nil }
 func (m *mockMessageStore) GetMessages(beginSeqNum, endSeqNum int) ([][]byte, error) { return nil, nil }
-func (m *mockMessageStore) Refresh() error                              { return nil }
-func (m *mockMessageStore) Reset() error                                { return nil }
-func (m *mockMessageStore) Close() error                                { return nil }
-func (m *mockMessageStore) IncrNextSenderMsgSeqNum() error {return nil}
-func (m *mockMessageStore) IncrNextTargetMsgSeqNum() error {return nil}
-func (m *mockMessageStore) IterateMessages(int, int, func([]byte) error)  error {return nil}
-func (m *mockMessageStore) SaveMessageAndIncrNextSenderMsgSeqNum(seqNum int, msg []byte) error { return m.saveMessageAndIncrError }
+func (m *mockMessageStore) Refresh() error                                           { return nil }
+func (m *mockMessageStore) Reset() error                                             { return nil }
+func (m *mockMessageStore) Close() error                                             { return nil }
+func (m *mockMessageStore) IncrNextSenderMsgSeqNum() error                           { return nil }
+func (m *mockMessageStore) IncrNextTargetMsgSeqNum() error                           { return nil }
+func (m *mockMessageStore) IterateMessages(int, int, func([]byte) error) error       { return nil }
+func (m *mockMessageStore) SaveMessageAndIncrNextSenderMsgSeqNum(seqNum int, msg []byte) error {
+	return m.saveMessageAndIncrError
+}
 func (m *mockMessageStore) SetCreationTime(time.Time) {}
 
 type mockLogFactory struct {
 	shouldFail bool
-	onEvent	func(string)
+	onEvent    func(string)
 }
 
 func (m *mockLogFactory) Create() (Log, error) {
@@ -143,28 +148,28 @@ type mockAddr struct {
 func (m *mockAddr) Network() string { return m.network }
 func (m *mockAddr) String() string  { return m.address }
 
-type mockConn struct {}
+type mockConn struct{}
 
 func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
 func (m *mockConn) Write(b []byte) (n int, err error)  { return len(b), nil }
 func (m *mockConn) Close() error                       { return nil }
-func (m *mockConn) LocalAddr() net.Addr               { return &mockAddr{network: "tcp", address: "127.0.0.1:8080"} }
-func (m *mockConn) RemoteAddr() net.Addr              { return &mockAddr{network: "tcp", address: "127.0.0.1:9090"} }
-func (m *mockConn) SetDeadline(t time.Time) error     { return nil }
-func (m *mockConn) SetReadDeadline(t time.Time) error { return nil }
+func (m *mockConn) LocalAddr() net.Addr                { return &mockAddr{network: "tcp", address: "127.0.0.1:8080"} }
+func (m *mockConn) RemoteAddr() net.Addr               { return &mockAddr{network: "tcp", address: "127.0.0.1:9090"} }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
 func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
 
-func (m *mockDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error){
+func (m *mockDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	return &mockConn{}, nil
 }
 
-type mockLog struct{
+type mockLog struct {
 	onEvent func(string)
 }
 
-func (m *mockLog) OnIncoming(s []byte)      {}
-func (m *mockLog) OnOutgoing(s []byte)      {}
-func (m *mockLog) OnEvent(s string)         {
+func (m *mockLog) OnIncoming(s []byte) {}
+func (m *mockLog) OnOutgoing(s []byte) {}
+func (m *mockLog) OnEvent(s string) {
 	if m.onEvent != nil {
 		m.onEvent(s)
 	}

--- a/session.go
+++ b/session.go
@@ -849,15 +849,15 @@ func (s *session) onAdmin(msg interface{}) {
 			return
 		}
 
-		if msg.err != nil {
-			close(msg.err)
-		}
-
 		s.messageIn = msg.messageIn
 		s.messageOut = msg.messageOut
 		s.sentReset = false
 
-		s.Connect(s)
+		err := s.Connect(s)
+		if msg.err != nil {
+			msg.err <- err
+			close(msg.err)
+		}
 
 	case stopReq:
 		s.Stop(s)

--- a/session_state.go
+++ b/session_state.go
@@ -36,7 +36,7 @@ func (sm *stateMachine) Start(s *session) {
 	sm.CheckSessionTime(s, time.Now())
 }
 
-func (sm *stateMachine) Connect(session *session) error{
+func (sm *stateMachine) Connect(session *session) error {
 	// No special logon logic needed for FIX Acceptors.
 	if !session.InitiateLogon {
 		sm.setState(session, logonState{})

--- a/session_state.go
+++ b/session_state.go
@@ -36,36 +36,37 @@ func (sm *stateMachine) Start(s *session) {
 	sm.CheckSessionTime(s, time.Now())
 }
 
-func (sm *stateMachine) Connect(session *session) {
+func (sm *stateMachine) Connect(session *session) error{
 	// No special logon logic needed for FIX Acceptors.
 	if !session.InitiateLogon {
 		sm.setState(session, logonState{})
-		return
+		return nil
 	}
 
 	if session.RefreshOnLogon {
 		if err := session.store.Refresh(); err != nil {
 			session.logError(err)
-			return
+			return err
 		}
 	}
 
 	if session.ResetOnLogon {
 		if err := session.store.Reset(); err != nil {
 			session.logError(err)
-			return
+			return err
 		}
 	}
 
 	session.log.OnEvent("Sending logon request")
 	if err := session.sendLogon(); err != nil {
 		session.logError(err)
-		return
+		return err
 	}
 
 	sm.setState(session, logonState{})
 	// Fire logon timeout event after the pre-configured delay period.
 	time.AfterFunc(session.LogonTimeout, func() { session.sessionEvent <- internal.LogonTimeout })
+	return nil
 }
 
 func (sm *stateMachine) Stop(session *session) {

--- a/session_test.go
+++ b/session_test.go
@@ -746,23 +746,23 @@ func (s *SessionSuite) TestOnAdminConnectRefreshOnLogon() {
 
 func (s *SessionSuite) TestOnAdminConnectError() {
 	dbError := fmt.Errorf("db error")
-		s.SetupTest()
-		errChannel := make(chan error, 1)
-		s.session.RefreshOnLogon = true
-		adminMsg := connect{
-			messageOut: s.Receiver.sendChannel,
-			err:        errChannel,
-		}
-		s.session.State = latentState{}
-		s.session.InitiateLogon = true
-		s.MockStore.On("Refresh").Return(dbError)
-		s.MockApp.On("ToAdmin")
-		s.session.onAdmin(adminMsg)
+	s.SetupTest()
+	errChannel := make(chan error, 1)
+	s.session.RefreshOnLogon = true
+	adminMsg := connect{
+		messageOut: s.Receiver.sendChannel,
+		err:        errChannel,
+	}
+	s.session.State = latentState{}
+	s.session.InitiateLogon = true
+	s.MockStore.On("Refresh").Return(dbError)
+	s.MockApp.On("ToAdmin")
+	s.session.onAdmin(adminMsg)
 
-		err := <-errChannel
-		s.Assert().Equal(err, dbError)
+	err := <-errChannel
+	s.Assert().Equal(err, dbError)
 
-		s.MockStore.AssertExpectations(s.T())
+	s.MockStore.AssertExpectations(s.T())
 
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -17,6 +17,7 @@ package quickfix
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -741,6 +742,28 @@ func (s *SessionSuite) TestOnAdminConnectRefreshOnLogon() {
 
 		s.MockStore.AssertExpectations(s.T())
 	}
+}
+
+func (s *SessionSuite) TestOnAdminConnectError() {
+	dbError := fmt.Errorf("db error")
+		s.SetupTest()
+		errChannel := make(chan error, 1)
+		s.session.RefreshOnLogon = true
+		adminMsg := connect{
+			messageOut: s.Receiver.sendChannel,
+			err:        errChannel,
+		}
+		s.session.State = latentState{}
+		s.session.InitiateLogon = true
+		s.MockStore.On("Refresh").Return(dbError)
+		s.MockApp.On("ToAdmin")
+		s.session.onAdmin(adminMsg)
+
+		err := <-errChannel
+		s.Assert().Equal(err, dbError)
+
+		s.MockStore.AssertExpectations(s.T())
+
 }
 
 func (s *SessionSuite) TestOnAdminConnectAccept() {


### PR DESCRIPTION
PR handles the logon error which can be observed when database is down for some period of time.

Way to reproduce that issue is to start fix initiator with sql database as store. Then stop database for a period of time and start it back up. This results in the following 2 issues:

- initiator stops its retrying logic as the logon error is ignored
- CPU usage is significantly increasing since session fails to transition to disconnected state and it constantly reads from a closed channel. It reads this closed channel [here](https://github.com/quickfixgo/quickfix/blob/4b2c4f2f04fc068185ba2b73d3a26b2daa758ce3/session.go#L917) and the handling of that closed channel [here](https://github.com/quickfixgo/quickfix/blob/4b2c4f2f04fc068185ba2b73d3a26b2daa758ce3/session.go#L919) is not working since it tries to transition the session to disconnected but we are already disconnected so that is a noop.

PR fixes it by handling the logon errors accordingly.