### PR TITLE
Speedup session start when SessionTime isn't set.

### DIFF
--- a/session.go
+++ b/session.go
@@ -906,14 +906,16 @@ func (s *session) run() {
 		}
 
 	})
-
-	// Without this sleep the ticker will be aligned at the millisecond which
-	// corresponds to the creation of the session. If the session creation
-	// happened at 07:00:00.678 and the session StartTime is 07:30:00, any new
-	// connection received between 07:30:00.000 and 07:30:00.677 will be
-	// rejected. Aligning the ticker with a round second fixes that.
-	time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second)))
-
+	
+	if s.SessionTime != nil {
+		// Without this sleep the ticker will be aligned at the millisecond which
+		// corresponds to the creation of the session. If the session creation
+		// happened at 07:00:00.678 and the session StartTime is 07:30:00, any new
+		// connection received between 07:30:00.000 and 07:30:00.677 will be
+		// rejected. Aligning the ticker with a round second fixes that.
+		time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second)))
+	}
+	
 	ticker := time.NewTicker(time.Second)
 
 	defer func() {

--- a/session.go
+++ b/session.go
@@ -906,7 +906,7 @@ func (s *session) run() {
 		}
 
 	})
-	
+
 	if s.SessionTime != nil {
 		// Without this sleep the ticker will be aligned at the millisecond which
 		// corresponds to the creation of the session. If the session creation
@@ -915,7 +915,7 @@ func (s *session) run() {
 		// rejected. Aligning the ticker with a round second fixes that.
 		time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second)))
 	}
-	
+
 	ticker := time.NewTicker(time.Second)
 
 	defer func() {


### PR DESCRIPTION
Added a check to skip sleeping to speedup session start for sessions without start and stop times.

There is no need to sync to the second when start and end times aren't used in the session. Removing the sleep saves valuable milliseconds in scenarios where the a quick session connection time is important.