### PR TITLE
Update devcontainer Go image to 1.25

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/go:1.23
+FROM mcr.microsoft.com/devcontainers/go:1.25

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-replica-set: replicaset
       - name: Unit test
@@ -173,7 +173,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-replica-set: replicaset
       - name: Install ruby


### PR DESCRIPTION
Hi there,
I hereby propose to upgrade the devcontainer Go image to 1.25 due to (a) Go 1.23 went EOL and (b) build failure due to yarn repository public key expired.