### PR TITLE
Test: resolve panic when MONGODB_TEST_CXN is not set

### DIFF
--- a/log/mongo/mongo_log_test.go
+++ b/log/mongo/mongo_log_test.go
@@ -110,6 +110,9 @@ func (suite *MongoLogTestSuite) TestMongoLog() {
 }
 
 func (suite *MongoLogTestSuite) TearDownTest() {
+	if suite.log == nil { // `TearDownTest` is called even if test is skipped
+		return
+	}
 	entry := generateEntry(&suite.log.sessionID)
 	_, err := suite.log.db.Database(suite.log.mongoDatabase).Collection(suite.log.messagesLogCollection).DeleteMany(context.Background(), entry)
 	require.Nil(suite.T(), err)


### PR DESCRIPTION
```
2026/05/10 15:13:35 MONGODB_TEST_CXN environment arg is not provided, skipping...
2026/05/10 15:13:35 MONGODB_TEST_CXN environment arg is not provided, skipping...
--- FAIL: TestMongoLogTestSuite (0.00s)
    --- FAIL: TestMongoLogTestSuite/TestMongoLog (0.00s)
        panic.go:336: test panicked: runtime error: invalid memory address or nil pointer dereference
            goroutine 21 [running]:
            runtime/debug.Stack()
```