### PR TITLE
fix: initialize Message sections in ParseMessageWithDataDictionary

### DIFF
--- a/message.go
+++ b/message.go
@@ -167,6 +167,18 @@ func ParseMessageWithDataDictionary(
 	transportDataDictionary *datadictionary.DataDictionary,
 	appDataDictionary *datadictionary.DataDictionary,
 ) (err error) {
+	// Ensure msg sections are initialized before locking their mutexes.
+	// A zero-value Message has nil rwLock pointers which would panic on Lock.
+	if msg.Header.rwLock == nil {
+		msg.Header.Init()
+	}
+	if msg.Body.rwLock == nil {
+		msg.Body.Init()
+	}
+	if msg.Trailer.rwLock == nil {
+		msg.Trailer.Init()
+	}
+
 	// Create msgparser before we go any further.
 	mp := &msgParser{
 		msg:                     msg,

--- a/parse_nil_test.go
+++ b/parse_nil_test.go
@@ -1,0 +1,21 @@
+package quickfix
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestParseMessageZeroValue ensures ParseMessage works on a zero-value Message
+// without panicking. Prior to the fix, passing &msg (zero-value) caused a nil
+// pointer dereference on rwLock because FieldMap.rwLock is a *sync.RWMutex that
+// is only set by Init().
+func TestParseMessageZeroValue(t *testing.T) {
+	rawMsg := bytes.NewBufferString("8=FIX.4.2\x019=104\x0135=D\x0134=2\x0149=TW\x0152=20140515-19:49:56.659\x0156=ISLD\x0111=100\x0121=1\x0140=1\x0154=1\x0155=TSLA\x0160=00010101-00:00:00.000\x0110=039\x01")
+
+	var msg Message
+	err := ParseMessage(&msg, rawMsg)
+	// A parse error is acceptable; a panic is not.
+	if err != nil {
+		t.Logf("ParseMessage returned error (acceptable): %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #390.

**Bug**

`ParseMessage` and `ParseMessageWithDataDictionary` accept a `*Message`
pointer but do not call `Init()` on the provided message. `FieldMap`
stores its mutex as `*sync.RWMutex` (a pointer), which is `nil` for a
zero-value struct. When `doParsing` immediately tries to lock that
mutex it panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
        sync.(*RWMutex).Lock(0x0)
        github.com/quickfixgo/quickfix.doParsing [...]
```

This affects any caller that takes the natural approach of declaring a
local variable and passing its address:

```go
var msg quickfix.Message
err := quickfix.ParseMessage(&msg, rawMsg) // panics
```

**Fix**

In `ParseMessageWithDataDictionary`, check each section's `rwLock`
before entering `doParsing`. If it is `nil`, call the section's
`Init()`. This matches what `NewMessage()` already does and is
idempotent for callers that pass an already-initialised message.

**Verification**

`TestParseMessageZeroValue` (added in `parse_nil_test.go`) panics
without the fix and passes with it. All existing tests continue to pass
with `-race`:

```
ok  github.com/quickfixgo/quickfix  14.172s
```