### PR TITLE
Fix duplicate reject reason value for ConditionallyRequiredFieldMissing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -31,7 +31,7 @@ const (
 	rejectReasonUnsupportedMessageType                    = 3
 	rejectReasonTagSpecifiedWithoutAValue                 = 4
 	rejectReasonValueIsIncorrect                          = 5
-	rejectReasonConditionallyRequiredFieldMissing         = 5
+	rejectReasonConditionallyRequiredFieldMissing         = 8
 	rejectReasonIncorrectDataFormatForValue               = 6
 	rejectReasonCompIDProblem                             = 9
 	rejectReasonSendingTimeAccuracyProblem                = 10

--- a/errors_test.go
+++ b/errors_test.go
@@ -141,7 +141,9 @@ func TestValueIsIncorrect(t *testing.T) {
 
 func TestConditionallyRequiredFieldMissing(t *testing.T) {
 	var (
-		expectedRejectReason         = 5
+		// Per FIX spec (tag 373/380 enum), ConditionallyRequiredFieldMissing
+		// is value 8, distinct from ValueIsIncorrect (value 5). See issue #721.
+		expectedRejectReason         = 8
 		expectedRefTagID         Tag = 44
 		expectedErrorString          = fmt.Sprintf("Conditionally Required Field Missing (%d)", expectedRefTagID)
 		expectedIsBusinessReject     = true
@@ -158,6 +160,10 @@ func TestConditionallyRequiredFieldMissing(t *testing.T) {
 	}
 	if msgRej.IsBusinessReject() != expectedIsBusinessReject {
 		t.Error("Expected IsBusinessReject to be true\n")
+	}
+	// Regression guard: the two reject reasons must not collide.
+	if msgRej.RejectReason() == ValueIsIncorrect(expectedRefTagID).RejectReason() {
+		t.Errorf("ConditionallyRequiredFieldMissing and ValueIsIncorrect must not share a reject reason value")
 	}
 }
 


### PR DESCRIPTION
Closes #721.

`rejectReasonConditionallyRequiredFieldMissing` was defined as `5`, the same value as `rejectReasonValueIsIncorrect`. Per FIX (tag 373 `SessionRejectReason` / tag 380 `BusinessRejectReason`) the correct value is `8`. Adds a regression test guarding against future collision of these two reject reasons.
