### PR TITLE
Reject out-of-range and empty integer field values

### DIFF
--- a/fix_int.go
+++ b/fix_int.go
@@ -17,6 +17,7 @@ package quickfix
 
 import (
 	"errors"
+	"math"
 	"strconv"
 )
 
@@ -31,6 +32,10 @@ const (
 
 // atoi is similar to the function in strconv, but is tuned for ints appearing in FIX field types.
 func atoi(d []byte) (int, error) {
+	if len(d) == 0 {
+		return 0, errors.New("empty bytes")
+	}
+
 	if d[0] == asciiMinus {
 		n, err := parseUInt(d[1:])
 		return (-1) * n, err
@@ -52,7 +57,13 @@ func parseUInt(d []byte) (n int, err error) {
 			return
 		}
 
-		n = n*10 + (int(dec) - ascii0)
+		digit := int(dec) - ascii0
+		if n > (math.MaxInt-digit)/10 {
+			err = errors.New("value out of range")
+			return
+		}
+
+		n = n*10 + digit
 	}
 
 	return

--- a/fix_int_test.go
+++ b/fix_int_test.go
@@ -42,6 +42,26 @@ func TestFIXInt_Int(t *testing.T) {
 	assert.Equal(t, 4, f.Int())
 }
 
+func TestFIXInt_ReadOutOfRange(t *testing.T) {
+	// Out-of-range values must be rejected, not silently wrapped.
+	for _, tc := range []string{
+		"9223372036854775808",  // math.MaxInt64 + 1
+		"18446744073709551617", // math.MaxUint64 + 1
+		"99999999999999999999",
+	} {
+		var field FIXInt
+		err := field.Read([]byte(tc))
+		assert.NotNilf(t, err, "expected out-of-range error for %q", tc)
+	}
+}
+
+func TestFIXInt_ReadEmpty(t *testing.T) {
+	// An empty value must return an error, not panic on d[0].
+	var field FIXInt
+	err := field.Read([]byte(""))
+	assert.NotNil(t, err, "expected error for empty bytes")
+}
+
 func BenchmarkFIXInt_Read(b *testing.B) {
 	intBytes := []byte("1500")
 	var field FIXInt


### PR DESCRIPTION
## Problem
`atoi`/`parseUInt` in `fix_int.go` back `FIXInt.Read`, which parses integer FIX fields including `MsgSeqNum (34)`, `BodyLength (9)`, and resend-range fields. Two issues:

1. **Silent overflow.** `parseUInt` accumulates `n = n*10 + digit` with no range check, so an out-of-range value wraps silently and is returned with a `nil` error:
   - `"9223372036854775808"` (MaxInt64+1) → `-9223372036854775808`
   - `"18446744073709551617"` (MaxUint64+1) → `1`
   - `"99999999999999999999"` → wrapped garbage

   A malformed or oversized field (e.g. tag 34) is therefore accepted with a corrupted value instead of being rejected, which can feed wrong values into sequence-number handling.

2. **Empty-input panic.** `atoi` reads `d[0]` before checking the length, so an empty integer field value panics with `index out of range [0] with length 0`.

## Fix
- `parseUInt` detects overflow before it happens (`n > (math.MaxInt-digit)/10`) and returns an error.
- `atoi` length-checks its input before indexing `d[0]`.

Both keep the allocation-free hot path. Added tests for the overflow and empty-input cases; existing tests and the full package suite pass.
