### PR TITLE
Validate each token of multi-value enum fields

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -16,6 +16,8 @@
 package quickfix
 
 import (
+	"bytes"
+
 	"github.com/quickfixgo/quickfix/datadictionary"
 )
 
@@ -385,10 +387,21 @@ func validateField(d *datadictionary.DataDictionary,
 		return nil
 	}
 
-	allowedValues := d.FieldTypeByTag[int(field.tag)].Enums
+	allowedValues := fieldType.Enums
 	if len(allowedValues) != 0 {
-		if _, validValue := allowedValues[string(field.value)]; !validValue {
-			return ValueIsIncorrect(field.tag)
+		switch fieldType.Type {
+		case "MULTIPLESTRINGVALUE", "MULTIPLEVALUESTRING", "MULTIPLECHARVALUE":
+			// These fields carry a space-delimited set of enum tokens, each of
+			// which must be individually valid (e.g. ExecInst "1 5" = two enums).
+			for _, component := range bytes.Split(field.value, []byte{' '}) {
+				if _, validValue := allowedValues[string(component)]; !validValue {
+					return ValueIsIncorrect(field.tag)
+				}
+			}
+		default:
+			if _, validValue := allowedValues[string(field.value)]; !validValue {
+				return ValueIsIncorrect(field.tag)
+			}
 		}
 	}
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -86,6 +86,8 @@ func TestValidate(t *testing.T) {
 		tcCheckUserDefinedFieldsDisabled(),
 		tcCheckUserDefinedFieldsDisabledFixT(),
 		tcMultipleRepeatingGroupFields(),
+		tcMultiValueEnumValid(),
+		tcMultiValueEnumInvalidComponent(),
 	}
 
 	msg := NewMessage()
@@ -655,6 +657,42 @@ func tcValueIsIncorrectFixT() validateTest {
 
 	return validateTest{
 		TestName:             "ValueIsIncorrect FIXT",
+		Validator:            validator,
+		MessageBytes:         msgBytes,
+		ExpectedRejectReason: rejectReasonValueIsIncorrect,
+		ExpectedRefTagID:     &tag,
+	}
+}
+
+func tcMultiValueEnumValid() validateTest {
+	dict, _ := datadictionary.Parse("spec/FIX43.xml")
+	validator := NewValidator(defaultValidatorSettings, dict, nil)
+
+	// ExecInst (tag 18) is a MULTIPLEVALUESTRING: a space-delimited set of
+	// individually-valid enum tokens (e.g. "Y M") must be accepted.
+	builder := createFIX43NewOrderSingle()
+	builder.Body.SetField(Tag(18), FIXString("Y M"))
+	msgBytes := builder.build()
+
+	return validateTest{
+		TestName:          "Multi-value enum valid",
+		Validator:         validator,
+		MessageBytes:      msgBytes,
+		DoNotExpectReject: true,
+	}
+}
+
+func tcMultiValueEnumInvalidComponent() validateTest {
+	dict, _ := datadictionary.Parse("spec/FIX43.xml")
+	validator := NewValidator(defaultValidatorSettings, dict, nil)
+
+	tag := Tag(18)
+	builder := createFIX43NewOrderSingle()
+	builder.Body.SetField(tag, FIXString("Y ZZ")) // ZZ is not a valid ExecInst enum
+	msgBytes := builder.build()
+
+	return validateTest{
+		TestName:             "Multi-value enum invalid component",
 		Validator:            validator,
 		MessageBytes:         msgBytes,
 		ExpectedRejectReason: rejectReasonValueIsIncorrect,


### PR DESCRIPTION
Fixes #754.

Fields of type `MULTIPLEVALUESTRING` / `MULTIPLESTRINGVALUE` / `MULTIPLECHARVALUE` carry a **space-delimited set** of enum tokens (per the FIX spec, e.g. `ExecInst = "1 5"` means NOTHELD + HELD). `validateField` looked the *entire* raw value up in the enum map:

```go
if _, validValue := allowedValues[string(field.value)]; !validValue {
    return ValueIsIncorrect(field.tag)
}
```

so any legal combination of two or more values was rejected with `ValueIsIncorrect` ("out of range"), even though each token is individually valid. Single-value fields still passed, which masked the bug.

## Fix

For the three multi-value field types, split the value on `' '` and validate every component against the enum map; all other types keep the original single-lookup path.

## Testing

Added two cases to `TestValidate` (FIX.4.3, `ExecInst` tag 18, a `MULTIPLEVALUESTRING`):

- `"Y M"` (two valid ExecInst enums) → accepted. Fails on the current code (`Unexpected reject: Value is incorrect`), passes with the fix.
- `"Y ZZ"` (one valid, one invalid token) → still correctly rejected with `ValueIsIncorrect` and the right ref tag.

The full package suite passes with no regression; `gofmt` clean.

Note: the code generator (`cmd/generate-fix/internal/template_helpers.go`) has the analogous single-lookup pattern in generated per-field setters — happy to follow up on that separately if you'd like it addressed too.
