### PR TITLE
Fix duplicate 10= checksum when resending a message ending in a repeating group

### DIFF
--- a/message.go
+++ b/message.go
@@ -313,6 +313,7 @@ func parseGroup(mp *msgParser, tags []Tag) {
 	for {
 		mp.fieldIndex++
 		mp.parsedFieldBytes = &mp.msg.fields[mp.fieldIndex]
+		preExtractBytes := mp.rawBytes
 		mp.rawBytes, _ = extractField(mp.parsedFieldBytes, mp.rawBytes)
 		mp.trailerBytes = mp.rawBytes
 
@@ -337,6 +338,10 @@ func parseGroup(mp *msgParser, tags []Tag) {
 			mp.msg.Body.add(dm)
 			mp.msg.Trailer.add(mp.msg.fields[mp.fieldIndex : mp.fieldIndex+1])
 			mp.foundTrailer = true
+			// Restore the buffer that still holds the trailer so the caller strips
+			// it from bodyBytes; otherwise the trailer stays embedded and resend
+			// emits a duplicate 10= tag.
+			mp.trailerBytes = preExtractBytes
 			break
 		} else {
 			// Found a body field outside the group.

--- a/message_test.go
+++ b/message_test.go
@@ -448,6 +448,26 @@ func (s *MessageSuite) TestReBuildWithRepeatingGroupMultipleEntriesInGroupForRes
 	s.True(bytes.Equal(expectedResendBytes, resendBytes), "Unexpected bytes,\n expected: %s\n  but was: %s", expectedResendBytes, resendBytes)
 }
 
+func (s *MessageSuite) TestReBuildWithRepeatingGroupWithDictionaryForResend() {
+	dict, dictErr := datadictionary.Parse("spec/FIX44.xml")
+	s.Nil(dictErr)
+
+	// A message whose body ends in a repeating group (453), parsed WITH a
+	// dictionary so parseGroup handles the group.
+	rawMsg := bytes.NewBufferString(
+		"8=FIX.4.4\x019=165\x0135=D\x0134=2\x0149=01001\x0150=01001a\x0152=20231231-20:19:41\x0156=TEST\x01" +
+			"1=acct1\x0111=13976\x0121=1\x0138=1\x0140=2\x0144=12\x0154=1\x0155=SYMABC\x0159=0\x0160=20231231-20:19:41\x01453=1\x01448=4501\x01447=D\x01452=28\x01" +
+			"10=026\x01")
+	s.Nil(ParseMessageWithDataDictionary(s.msg, rawMsg, dict, dict))
+
+	// The trailer must not stay embedded in bodyBytes.
+	s.False(bytes.Contains(s.msg.bodyBytes, []byte("\x0110=")), "trailer leaked into bodyBytes: %s", s.msg.bodyBytes)
+
+	// A resend rebuilt from bodyBytes must carry exactly one 10= checksum.
+	resendBytes := s.msg.buildWithBodyBytes(s.msg.bodyBytes)
+	s.Equal(1, bytes.Count(resendBytes, []byte("\x0110=")), "expected exactly one 10= checksum, got: %s", resendBytes)
+}
+
 func (s *MessageSuite) TestReverseRoute() {
 	s.Nil(ParseMessage(s.msg, bytes.NewBufferString("8=FIX.4.29=17135=D34=249=TW50=KK52=20060102-15:04:0556=ISLD57=AP144=BB115=JCD116=CS128=MG129=CB142=JV143=RY145=BH11=ID21=338=10040=w54=155=INTC60=20060102-15:04:0510=123")))
 


### PR DESCRIPTION
Fixes #761.

## Problem
When a stored outbound message whose body ends in a repeating group is parsed with a `DataDictionary` (the resend path always uses one), `parseGroup` leaks the `10=` trailer into `Message.bodyBytes`. On resend, `buildWithBodyBytes` writes that contaminated `bodyBytes` and appends a freshly computed `10=` on top — producing **two `10=` tags** and a wrong `BodyLength`. The counterparty rejects with `Invalid checksum` and drops the session.

All three conditions are required: a `DataDictionary` is configured, the body contains a repeating group, and the counterparty sends a `ResendRequest`.

## Root cause
`parseGroup`'s loop sets `mp.trailerBytes = mp.rawBytes` *after* `extractField` consumes each field. When it consumes the trailer field (`10=NNN`), `rawBytes` is empty, so `trailerBytes = ""`. The caller's strip

```go
if len(mp.msg.bodyBytes) > len(mp.trailerBytes) {
    mp.msg.bodyBytes = mp.msg.bodyBytes[:len(mp.msg.bodyBytes)-len(mp.trailerBytes)]
}
```

then removes zero bytes, leaving the trailer embedded. The non-group `default` path is unaffected because it sets `trailerBytes` while `rawBytes` still includes the upcoming trailer.

## Fix
`parseGroup` snapshots the pre-extract buffer and, on detecting the trailer field, restores `trailerBytes` to it (the buffer that still holds `10=NNN`), so the strip removes the trailer exactly as the non-group path does.

## Test
Added `TestReBuildWithRepeatingGroupWithDictionaryForResend`: parses a message ending in a `453` group with a FIX44 dictionary and asserts (a) `bodyBytes` no longer contains the trailer and (b) the resend built from `bodyBytes` carries exactly one `10=`. Fails before, passes after. Existing tests and the full package suite pass.
