### PR TITLE
Bounds check the parser against two panics on malformed input

### DIFF
--- a/fix_int.go
+++ b/fix_int.go
@@ -31,6 +31,10 @@ const (
 
 // atoi is similar to the function in strconv, but is tuned for ints appearing in FIX field types.
 func atoi(d []byte) (int, error) {
+	if len(d) == 0 {
+		return 0, errors.New("empty bytes")
+	}
+
 	if d[0] == asciiMinus {
 		n, err := parseUInt(d[1:])
 		return (-1) * n, err

--- a/fix_int_test.go
+++ b/fix_int_test.go
@@ -35,6 +35,9 @@ func TestFIXInt_Read(t *testing.T) {
 
 	err = field.Read([]byte("blah"))
 	assert.NotNil(t, err, "Unexpected error")
+
+	err = field.Read([]byte(""))
+	assert.NotNil(t, err, "Unexpected error")
 }
 
 func TestFIXInt_Int(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -553,6 +553,12 @@ func extractXMLDataField(parsedFieldBytes *TagValue, buffer []byte, dataLen int)
 		remBytes = buffer
 		return
 	}
+	// Compared against the remaining buffer so a large dataLen cannot overflow int.
+	if dataLen < 0 || dataLen > len(buffer)-endIndex-2 {
+		err = parseError{OrigError: fmt.Sprintf("extractXMLDataField: XMLDataLen %d exceeds remaining buffer of %d bytes", dataLen, len(buffer)-endIndex-2)}
+		remBytes = buffer
+		return
+	}
 	endIndex += dataLen + 1
 
 	err = parsedFieldBytes.parse(buffer[:endIndex+1])

--- a/message_test.go
+++ b/message_test.go
@@ -64,6 +64,38 @@ func (s *MessageSuite) TestParseMessageEmpty() {
 	s.NotNil(err)
 }
 
+func (s *MessageSuite) TestParseMessageXMLDataLenOutOfRange() {
+	var tests = []struct {
+		name   string
+		rawMsg string
+	}{
+		{"overrun", "8=FIX.4.29=2035=n34=249=CME56=OAEAAAN212=999999999213=<x/>10=000"},
+		{"int overflow", "8=FIX.4.29=2035=n34=249=CME56=OAEAAAN212=9223372036854775807213=<x/>10=000"},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.NotNil(ParseMessage(NewMessage(), bytes.NewBufferString(test.rawMsg)))
+		})
+	}
+}
+
+func (s *MessageSuite) TestParseMessageEmptyIntField() {
+	var tests = []struct {
+		name   string
+		rawMsg string
+	}{
+		{"body length", "8=FIX.4.29=35=D34=249=TW56=ISLD10=000"},
+		{"xml data len", "8=FIX.4.29=2035=n34=249=CME56=OAEAAAN212=213=<x/>10=000"},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.NotNil(ParseMessage(NewMessage(), bytes.NewBufferString(test.rawMsg)))
+		})
+	}
+}
+
 func (s *MessageSuite) TestParseMessage() {
 	rawMsg := bytes.NewBufferString("8=FIX.4.29=10435=D34=249=TW52=20140515-19:49:56.65956=ISLD11=10021=140=154=155=TSLA60=00010101-00:00:00.00010=039")
 


### PR DESCRIPTION
Two shapes a peer can put on the wire panic the parser on the session read goroutine, so a single malformed message takes the session down instead of being rejected.

`atoi` in fix_int.go indexes `d[0]` with no length check, so any empty-valued int field the parser reads back panics with index out of range. `parseUInt` already handled the empty case; `atoi` did not. Repro: `8=FIX.4.2|9=|35=D|34=2|49=TW|56=ISLD|10=000|`.

`extractXMLDataField` in message.go takes its slice bound straight from XMLDataLen(212) and does `endIndex += dataLen + 1` before slicing, with no validation. A large value slices past the buffer, and a large enough one overflows int and slices negative. Repro: `8=FIX.4.2|9=20|35=n|34=2|49=CME|56=OAEAAAN|212=999999999|213=<x/>|10=000|`, and the same with `212=9223372036854775807`.

Both are now rejected with an error instead. Four table cases added in the existing test-file style, plus an empty-input case on TestFIXInt_Read; each fails with a panic before the patch. `make vet`, `make build-src` and `make test-ci` are clean locally (log/mongo needs a live MongoDB and fails the same way on an unpatched tree).

Fixes the parser half of #678. Found by fuzzing an application built on this library.