### PR TITLE
when send a logon,keep tagNextExpectedMsgSeqNum val

### DIFF
--- a/session.go
+++ b/session.go
@@ -202,7 +202,7 @@ func (s *session) sendLogonInReplyTo(setResetSeqNum bool, inReplyTo *Message) er
 		} else {
 			// We are sending a logon.
 			nextseqnum := s.store.NextTargetMsgSeqNum()
-			logon.Body.SetField(tagNextExpectedMsgSeqNum, FIXInt(nextseqnum+1))
+			logon.Body.SetField(tagNextExpectedMsgSeqNum, FIXInt(nextseqnum))
 		}
 	}
 


### PR DESCRIPTION
When we initiate a logon, NextExpectedMsgSeqNum should remain unchanged instead of incrementing. Otherwise, it will exceed the counterparty's actual sequence number, triggering an error.
NextExpectedMsgSeqNum (789) is higher than the next-to-be-assigned sequence