### PR TITLE
Remove redundant buffer Reset

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -157,7 +157,6 @@ func (p *parser) ReadMessage() (msgBytes *bytes.Buffer, err error) {
 	}
 
 	msgBytes = new(bytes.Buffer)
-	msgBytes.Reset()
 	msgBytes.Write(p.buffer[:index])
 	p.buffer = p.buffer[index:]
 


### PR DESCRIPTION
Remove a call to Reset a bytes.Buffer immediately after it is initialised as I believe this is unnecessary